### PR TITLE
updating and refactoring summarize() functions

### DIFF
--- a/lib/journey/node/upstream_dependencies/computations.ex
+++ b/lib/journey/node/upstream_dependencies/computations.ex
@@ -59,19 +59,18 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       conditions
       |> Enum.map(fn c -> evaluate_computation_for_readiness(all_executions_values, c) end)
 
-    if Enum.any?(results, fn r -> r.ready? end) do
-      %{
-        ready?: true,
-        conditions_met: Enum.flat_map(results, fn r -> r.conditions_met end),
-        conditions_not_met: Enum.flat_map(results, fn r -> r.conditions_not_met end)
+    any_met = Enum.any?(results, fn r -> r.ready? end)
+
+    %{
+      ready?: any_met,
+      conditions_met: Enum.flat_map(results, fn r -> r.conditions_met end),
+      conditions_not_met: Enum.flat_map(results, fn r -> r.conditions_not_met end),
+      structure: %{
+        type: :or,
+        met?: any_met,
+        children: Enum.map(results, fn r -> r.structure end)
       }
-    else
-      %{
-        ready?: false,
-        conditions_met: Enum.flat_map(results, fn r -> r.conditions_met end),
-        conditions_not_met: Enum.flat_map(results, fn r -> r.conditions_not_met end)
-      }
-    end
+    }
   end
 
   def evaluate_computation_for_readiness(all_executions_values, {:and, conditions}) when is_list(conditions) do
@@ -79,19 +78,18 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       conditions
       |> Enum.map(fn c -> evaluate_computation_for_readiness(all_executions_values, c) end)
 
-    if Enum.all?(results, fn c -> c.ready? end) do
-      %{
-        ready?: true,
-        conditions_met: Enum.flat_map(results, fn r -> r.conditions_met end),
-        conditions_not_met: Enum.flat_map(results, fn r -> r.conditions_not_met end)
+    all_met = Enum.all?(results, fn c -> c.ready? end)
+
+    %{
+      ready?: all_met,
+      conditions_met: Enum.flat_map(results, fn r -> r.conditions_met end),
+      conditions_not_met: Enum.flat_map(results, fn r -> r.conditions_not_met end),
+      structure: %{
+        type: :and,
+        met?: all_met,
+        children: Enum.map(results, fn r -> r.structure end)
       }
-    else
-      %{
-        ready?: false,
-        conditions_met: Enum.flat_map(results, fn r -> r.conditions_met end),
-        conditions_not_met: Enum.flat_map(results, fn r -> r.conditions_not_met end)
-      }
-    end
+    }
   end
 
   def evaluate_computation_for_readiness(all_executions_values, {upstream_node_name, f_condition})
@@ -104,21 +102,19 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       raise "missing value node for #{upstream_node_name}"
     end
 
-    if f_condition.(relevant_value_node) do
-      %{
-        ready?: true,
-        conditions_met: [%{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}],
-        conditions_not_met: []
+    condition_met = f_condition.(relevant_value_node)
+    condition_data = %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}
+
+    %{
+      ready?: condition_met,
+      conditions_met: if(condition_met, do: [condition_data], else: []),
+      conditions_not_met: if(condition_met, do: [], else: [condition_data]),
+      structure: %{
+        type: :leaf,
+        met?: condition_met,
+        condition: condition_data
       }
-    else
-      %{
-        ready?: false,
-        conditions_met: [],
-        conditions_not_met: [
-          %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}
-        ]
-      }
-    end
+    }
   end
 
   def evaluate_computation_for_readiness(all_executions_values, {:not, {upstream_node_name, f_condition}})
@@ -131,20 +127,23 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       raise "missing value node for #{upstream_node_name}"
     end
 
-    if f_condition.(relevant_value_node) do
-      %{
-        ready?: false,
-        conditions_met: [],
-        conditions_not_met: [
-          %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :negated}
-        ]
+    inner_condition_met = f_condition.(relevant_value_node)
+    negated_condition_met = not inner_condition_met
+    condition_data = %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :negated}
+
+    %{
+      ready?: negated_condition_met,
+      conditions_met: if(negated_condition_met, do: [condition_data], else: []),
+      conditions_not_met: if(negated_condition_met, do: [], else: [condition_data]),
+      structure: %{
+        type: :not,
+        met?: negated_condition_met,
+        child: %{
+          type: :leaf,
+          met?: inner_condition_met,
+          condition: %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}
+        }
       }
-    else
-      %{
-        ready?: true,
-        conditions_met: [%{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :negated}],
-        conditions_not_met: []
-      }
-    end
+    }
   end
 end

--- a/lib/journey/node/upstream_dependencies/computations.ex
+++ b/lib/journey/node/upstream_dependencies/computations.ex
@@ -107,14 +107,16 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
     if f_condition.(relevant_value_node) do
       %{
         ready?: true,
-        conditions_met: [%{upstream_node: relevant_value_node, f_condition: f_condition}],
+        conditions_met: [%{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}],
         conditions_not_met: []
       }
     else
       %{
         ready?: false,
         conditions_met: [],
-        conditions_not_met: [%{upstream_node: relevant_value_node, f_condition: f_condition}]
+        conditions_not_met: [
+          %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :direct}
+        ]
       }
     end
   end
@@ -133,12 +135,14 @@ defmodule Journey.Node.UpstreamDependencies.Computations do
       %{
         ready?: false,
         conditions_met: [],
-        conditions_not_met: [%{upstream_node: relevant_value_node, f_condition: f_condition}]
+        conditions_not_met: [
+          %{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :negated}
+        ]
       }
     else
       %{
         ready?: true,
-        conditions_met: [%{upstream_node: relevant_value_node, f_condition: f_condition}],
+        conditions_met: [%{upstream_node: relevant_value_node, f_condition: f_condition, condition_context: :negated}],
         conditions_not_met: []
       }
     end

--- a/lib/journey/tools.ex
+++ b/lib/journey/tools.ex
@@ -556,11 +556,13 @@ defmodule Journey.Tools do
       do: "  - #{node_name}: #{computation_state_to_text(state)} | #{inspect(computation_type)}\n",
       else: ""
     ) <>
-      Enum.map_join(readiness.conditions_met, "", fn %{upstream_node: v, f_condition: f} ->
-        "#{indent}✅ #{inspect(v.node_name)} | #{f_name(f)} | rev #{v.ex_revision}\n"
+      Enum.map_join(readiness.conditions_met, "", fn condition_map = %{upstream_node: v, f_condition: f} ->
+        node_display = format_node_name_with_context(v.node_name, condition_map)
+        "#{indent}✅ #{node_display} | #{f_name(f)} | rev #{v.ex_revision}\n"
       end) <>
-      Enum.map_join(readiness.conditions_not_met, "\n", fn %{upstream_node: v, f_condition: f} ->
-        "#{indent}🛑 #{inspect(v.node_name)} | #{f_name(f)}"
+      Enum.map_join(readiness.conditions_not_met, "\n", fn condition_map = %{upstream_node: v, f_condition: f} ->
+        node_display = format_node_name_with_context(v.node_name, condition_map)
+        "#{indent}🛑 #{node_display} | #{f_name(f)}"
       end)
   end
 
@@ -570,6 +572,14 @@ defmodule Journey.Tools do
       :execution_id -> node_value
       :last_updated_at -> node_value
       _ -> inspect(node_value)
+    end
+  end
+
+  # Helper function to format node names with conditional context
+  defp format_node_name_with_context(node_name, condition_map) do
+    case Map.get(condition_map, :condition_context, :direct) do
+      :negated -> "not(#{inspect(node_name)})"
+      :direct -> inspect(node_name)
     end
   end
 end

--- a/lib/journey/tools.ex
+++ b/lib/journey/tools.ex
@@ -93,12 +93,12 @@ defmodule Journey.Tools do
       ...>   input(:value),
       ...>   compute(:double, [:value], fn %{value: v} -> {:ok, v * 2} end)
       ...> ])
-      iex> {:ok, execution} = Journey.start_execution(graph)
+      iex> execution = Journey.start_execution(graph)
       iex> Journey.Tools.computation_state(execution.id, :double)
       :not_set
       iex> Journey.Tools.computation_state(execution.id, :value)
       :not_compute_node
-      iex> {:ok, execution} = Journey.set_value(execution, :value, 5)
+      iex> execution = Journey.set_value(execution, :value, 5)
       iex> {:ok, _result} = Journey.get_value(execution, :double, wait_new: true)
       iex> Journey.Tools.computation_state(execution.id, :double)
       :success
@@ -440,7 +440,7 @@ defmodule Journey.Tools do
          computed_with: computed_with,
          ex_revision_at_completion: ex_revision_at_completion
        }) do
-    "  - :#{node_name} (#{id}): #{inspect(state)} | #{inspect(computation_type)} | rev #{ex_revision_at_completion}\n" <>
+    "  - :#{node_name} (#{id}): #{computation_state_to_text(state)} | #{inspect(computation_type)} | rev #{ex_revision_at_completion}\n" <>
       "    inputs used: \n" <>
       case computed_with do
         nil ->
@@ -473,7 +473,10 @@ defmodule Journey.Tools do
 
     indent = if(with_header?, do: "       ", else: "")
 
-    if(with_header?, do: "  - #{node_name}: #{inspect(state)} | #{inspect(computation_type)}\n", else: "") <>
+    if(with_header?,
+      do: "  - #{node_name}: #{computation_state_to_text(state)} | #{inspect(computation_type)}\n",
+      else: ""
+    ) <>
       Enum.map_join(readiness.conditions_met, "", fn %{upstream_node: v, f_condition: f} ->
         "#{indent}✅ #{inspect(v.node_name)} | #{f_name(f)} | rev #{v.ex_revision}\n"
       end) <>

--- a/test/journey/scheduler/mutate_test.exs
+++ b/test/journey/scheduler/mutate_test.exs
@@ -25,7 +25,7 @@ defmodule Journey.Scheduler.Scheduler.MutateTest do
       execution = execution |> Journey.set_value(:switch_position, "on")
       wait_for_switch_to_be_turned_back_off(execution, 10)
 
-      Journey.Tools.summarize(execution.id) |> Journey.Tools.summarize_to_text() |> IO.puts()
+      Journey.Tools.summarize_as_text(execution.id) |> IO.puts()
     end
   end
 

--- a/test/journey/scheduler/mutate_test.exs
+++ b/test/journey/scheduler/mutate_test.exs
@@ -25,7 +25,7 @@ defmodule Journey.Scheduler.Scheduler.MutateTest do
       execution = execution |> Journey.set_value(:switch_position, "on")
       wait_for_switch_to_be_turned_back_off(execution, 10)
 
-      Journey.Tools.summarize(execution.id) |> IO.puts()
+      Journey.Tools.summarize(execution.id) |> Journey.Tools.summarize_to_text() |> IO.puts()
     end
   end
 

--- a/test/journey/tools_test.exs
+++ b/test/journey/tools_test.exs
@@ -122,8 +122,8 @@ defmodule Journey.ToolsTest do
              🛑 :greeting | &provided?/1
         - reminder: ⬜ :not_set (not yet attempted) | :compute
              :and
-                 🛑 :greeting | &provided?/1
-                 🛑 :time_to_issue_reminder_schedule | &provided?/1
+              ├─ 🛑 :greeting | &provided?/1
+              └─ 🛑 :time_to_issue_reminder_schedule | &provided?/1
         - greeting: ⬜ :not_set (not yet attempted) | :compute
              🛑 :user_name | &provided?/1
       """
@@ -404,15 +404,15 @@ defmodule Journey.ToolsTest do
       - Outstanding:
         - user_applied_or_card_mailed: ⬜ :not_set (not yet attempted) | :compute
              :or
-                 🛑 :user_applied | &true?/1
-                 🛑 :card_mailed | &true?/1
+              ├─ 🛑 :user_applied | &true?/1
+              └─ 🛑 :card_mailed | &true?/1
         - send_welcome: ⬜ :not_set (not yet attempted) | :compute
              🛑 :user_name | &provided?/1
         - send_approval_notice: ⬜ :not_set (not yet attempted) | :compute
              :and
-                 🛑 :user_applied | &true?/1
-                 🛑 :user_approved | &true?/1
-                 🛑 :not(:user_requested_card) | &true?/1
+              ├─ 🛑 :user_applied | &true?/1
+              ├─ 🛑 :user_approved | &true?/1
+              └─ 🛑 :not(:user_requested_card) | &true?/1
       """
 
       assert redacted_result == String.trim(expected_output)

--- a/test/journey/tools_test.exs
+++ b/test/journey/tools_test.exs
@@ -121,8 +121,9 @@ defmodule Journey.ToolsTest do
         - time_to_issue_reminder_schedule: ⬜ :not_set (not yet attempted) | :schedule_once
              🛑 :greeting | &provided?/1
         - reminder: ⬜ :not_set (not yet attempted) | :compute
-             🛑 :greeting | &provided?/1
-             🛑 :time_to_issue_reminder_schedule | &provided?/1
+             :and
+                 🛑 :greeting | &provided?/1
+                 🛑 :time_to_issue_reminder_schedule | &provided?/1
         - greeting: ⬜ :not_set (not yet attempted) | :compute
              🛑 :user_name | &provided?/1
       """
@@ -313,6 +314,18 @@ defmodule Journey.ToolsTest do
               ]
             },
             fn _ -> {:ok, "Follow up message"} end
+          ),
+          # 4. Complex :or with multiple unmet conditions
+          compute(
+            :user_applied_or_card_mailed,
+            {
+              :or,
+              [
+                {:user_applied, &true?/1},
+                {:card_mailed, &true?/1}
+              ]
+            },
+            fn _ -> {:ok, "Follow up message"} end
           )
         ])
 
@@ -350,8 +363,8 @@ defmodule Journey.ToolsTest do
       - Last updated at: REDACTED UTC | REDACTED seconds ago
       - Duration: REDACTED seconds
       - Revision: 4
-      - # of Values: 4 (set) / 11 (total)
-      - # of Computations: 4
+      - # of Values: 4 (set) / 12 (total)
+      - # of Computations: 5
 
       Values:
       - Set:
@@ -373,6 +386,7 @@ defmodule Journey.ToolsTest do
         - send_approval_notice: <unk> | :compute
         - send_welcome: <unk> | :compute
         - user_applied: <unk> | :input
+        - user_applied_or_card_mailed: <unk> | :compute
         - user_approved: <unk> | :input
         - user_name: <unk> | :input
         - user_requested_card: <unk> | :input  
@@ -388,12 +402,17 @@ defmodule Journey.ToolsTest do
              :user_requested_card (rev 0)
 
       - Outstanding:
+        - user_applied_or_card_mailed: ⬜ :not_set (not yet attempted) | :compute
+             :or
+                 🛑 :user_applied | &true?/1
+                 🛑 :card_mailed | &true?/1
         - send_welcome: ⬜ :not_set (not yet attempted) | :compute
              🛑 :user_name | &provided?/1
         - send_approval_notice: ⬜ :not_set (not yet attempted) | :compute
-             ✅ not(:user_requested_card) | &true?/1 | rev 0
-             🛑 :user_applied | &true?/1
-             🛑 :user_approved | &true?/1
+             :and
+                 🛑 :user_applied | &true?/1
+                 🛑 :user_approved | &true?/1
+                 🛑 :not(:user_requested_card) | &true?/1
       """
 
       assert redacted_result == String.trim(expected_output)

--- a/test/journey/tools_test.exs
+++ b/test/journey/tools_test.exs
@@ -85,24 +85,6 @@ defmodule Journey.ToolsTest do
         |> redact_text_duration()
         |> redact_text_seconds_ago()
 
-      # |> redact_text_system_node_values()
-
-      # Test key parts of the output rather than exact match due to complexity
-      #      assert redacted_result =~ "Execution summary:"
-      #      assert redacted_result =~ "- ID: 'REDACTED'"
-      #      assert redacted_result =~ "- Graph: 'test graph 1 Elixir.Journey.Test.Support' | '1.0.0'"
-      #      assert redacted_result =~ "- Archived at: not archived"
-      #      assert redacted_result =~ "- Created at: REDACTED UTC | REDACTED seconds ago"
-      #      assert redacted_result =~ "- Last updated at: REDACTED UTC | REDACTED seconds ago"
-      #      assert redacted_result =~ "- Duration: REDACTED seconds"
-      #      assert redacted_result =~ "- Revision: 0"
-      #      assert redacted_result =~ "Values:"
-      #      assert redacted_result =~ "- Set:"
-      #      assert redacted_result =~ "- Not set:"
-      #      assert redacted_result =~ "user_name: <unk> | :input"
-      #      assert redacted_result =~ "Computations:"
-      #      assert redacted_result =~ "- Outstanding:"
-
       # Complete expected output as living documentation for engineers
       expected_output = """
       Execution summary:

--- a/test_load/sunny_day.ex
+++ b/test_load/sunny_day.ex
@@ -27,12 +27,12 @@ defmodule LoadTest.SunnyDay do
 
               _huh ->
                 Logger.error("#{e.id}: execution failed.")
-                Journey.Tools.summarize(e.id) |> IO.puts()
+                Journey.Tools.summarize(e.id) |> Journey.Tools.summarize_to_text() |> IO.puts()
             end
           rescue
             exception ->
               Logger.error("#{inspect(e.id)}: execution raised an exception: #{inspect(exception)}")
-              Journey.Tools.summarize(e.id) |> IO.puts()
+              Journey.Tools.summarize(e.id) |> Journey.Tools.summarize_to_text() |> IO.puts()
           end
         end)
       end

--- a/test_load/sunny_day.ex
+++ b/test_load/sunny_day.ex
@@ -27,12 +27,12 @@ defmodule LoadTest.SunnyDay do
 
               _huh ->
                 Logger.error("#{e.id}: execution failed.")
-                Journey.Tools.summarize(e.id) |> Journey.Tools.summarize_to_text() |> IO.puts()
+                Journey.Tools.summarize_as_text(e.id) |> IO.puts()
             end
           rescue
             exception ->
               Logger.error("#{inspect(e.id)}: execution raised an exception: #{inspect(exception)}")
-              Journey.Tools.summarize(e.id) |> Journey.Tools.summarize_to_text() |> IO.puts()
+              Journey.Tools.summarize_as_text(e.id) |> IO.puts()
           end
         end)
       end


### PR DESCRIPTION
```
iex> "EXECX5J2Z231R8J3AEG418TB" |> Journey.Tools.summarize_as_text() |> IO.puts()
Execution summary:
- ID: 'EXECX5J2Z231R8J3AEG418TB'
- Graph: 'Horoscope Demo App' | 'v1.0.1'
- Archived at: not archived
- Created at: 2025-08-24 06:41:20Z UTC | 2999 seconds ago
- Last updated at: 2025-08-24 06:41:54Z UTC | 2965 seconds ago
- Duration: 34 seconds
- Revision: 23
- # of Values: 14 (set) / 27 (total)
- # of Computations: 11

Values:
- Set:
  - dev_show_journey_execution_summary: 'true' | :input
    set at 2025-08-24 06:41:54Z | rev: 23

  - last_updated_at: '1756017714' | :input
    set at 2025-08-24 06:41:54Z | rev: 23

  - dev_show_other_computed_values: 'true' | :input
    set at 2025-08-24 06:41:47Z | rev: 22

  - horoscope: '"There is a grateful houseplant out there that would not exist if not for you. A curious kitty will side-glance at you approvingly. This cosmic wisdom was code-crafted for M****."' | :compute
    computed at 2025-08-24 06:41:28Z | rev: 15

  - pet_preference: '"cats"' | :input
    set at 2025-08-24 06:41:27Z | rev: 13

  - zodiac_sign: '"Aquarius"' | :compute
    computed at 2025-08-24 06:41:25Z | rev: 12

  - birth_day: '23' | :input
    set at 2025-08-24 06:41:25Z | rev: 10

  - birth_month: '"January"' | :input
    set at 2025-08-24 06:41:23Z | rev: 9

  - anonymize_name: '"updated :name"' | :mutate
    computed at 2025-08-24 06:41:20Z | rev: 8

  - name_validation: '"not bowser"' | :compute
    computed at 2025-08-24 06:41:20Z | rev: 6

  - name: '"M****"' | :input
    set at 2025-08-24 06:41:20Z | rev: 4

  - schedule_archive: '1757227280' | :schedule_once
    computed at 2025-08-24 06:41:20Z | rev: 3

  - email_address: '"me@example.com"' | :input
    set at 2025-08-24 06:41:20Z | rev: 2

  - execution_id: 'EXECX5J2Z231R8J3AEG418TB' | :input
    set at 2025-08-24 06:41:20Z | rev: 0


- Not set:
  - auto_archive: <unk> | :compute
  - dev_show_all_values: <unk> | :input
  - dev_show_computation_states: <unk> | :input
  - dev_show_execution_history: <unk> | :input
  - dev_show_flow_analytics_json: <unk> | :input
  - dev_show_flow_analytics_table: <unk> | :input
  - dev_show_more: <unk> | :input
  - dev_show_workflow_graph: <unk> | :input
  - email_horoscope: <unk> | :compute
  - send_weekly_reminder: <unk> | :compute
  - show_all_computations: <unk> | :input
  - subscribe_weekly: <unk> | :input
  - weekly_reminder_schedule: <unk> | :schedule_recurring  

Computations:
- Completed:
  - :email_horoscope (CMP52LBZA5VR98DVVT39T4J): ❌ :failed | :compute | rev 21
    inputs used: 
       <none>

  - :email_horoscope (CMP87LDB0ZM2M58Y2M83HM8): ❌ :failed | :compute | rev 19
    inputs used: 
       <none>

  - :email_horoscope (CMPGV63E61V31H1262YERRJ): ❌ :failed | :compute | rev 17
    inputs used: 
       <none>

  - :horoscope (CMPRV278VHGG8TMDJY95T6X): ✅ :success | :compute | rev 15
    inputs used: 
       :name (rev 4)
       :zodiac_sign (rev 12)
       :pet_preference (rev 13)
  - :zodiac_sign (CMP19D2AV27471X93GY8MDJ): ✅ :success | :compute | rev 12
    inputs used: 
       :birth_month (rev 9)
       :birth_day (rev 10)
       :name_validation (rev 6)
  - :anonymize_name (CMPJ3YX5610MGGL1XD4H967): ✅ :success | :mutate | rev 8
    inputs used: 
       :name_validation (rev 6)
  - :name_validation (CMP5GB9AAGT36M5X3AG0V3R): ✅ :success | :compute | rev 6
    inputs used: 
       :name (rev 4)
  - :schedule_archive (CMPAD1A436X9EL6Y94GYRYM): ✅ :success | :schedule_once | rev 3
    inputs used: 
       :last_updated_at (rev 0)

- Outstanding:
  - weekly_reminder_schedule: ⬜ :not_set (not yet attempted) | :schedule_recurring
       :and
        ├─ 🛑 :subscribe_weekly | &true?/1
        └─ ✅ :horoscope | &provided?/1 | rev 15
  - send_weekly_reminder: ⬜ :not_set (not yet attempted) | :compute
       :and
        ├─ 🛑 :subscribe_weekly | &true?/1
        ├─ 🛑 :weekly_reminder_schedule | &provided?/1
        └─ ✅ :email_address | &provided?/1 | rev 2
  - auto_archive: ⬜ :not_set (not yet attempted) | :compute
       🛑 :schedule_archive | &provided?/1
 ```