### PR TITLE
list_executions: switch to database-level value filtering, + SQL injection test, + unique constraint on value execution id + name

### DIFF
--- a/lib/journey/executions.ex
+++ b/lib/journey/executions.ex
@@ -732,38 +732,192 @@ defmodule Journey.Executions do
     :ok
   end
 
-  defp add_filters(q, value_filters) do
-    from(e in q, preload: [:values, :computations])
-    |> Journey.Repo.all()
-    |> Enum.map(fn execution -> convert_node_names_to_atoms(execution) end)
-    |> Enum.filter(fn execution ->
-      Enum.all?(value_filters, fn
-        {value_node_name, comparator, value_node_value}
-        when is_atom(value_node_name) and
-               (comparator in [:eq, :neq, :lt, :lte, :gt, :gte, :in, :not_in] or is_function(comparator)) ->
-          value_node = find_value_by_name(execution, value_node_name)
-          value_node != nil and cmp(comparator).(value_node.node_value, value_node_value)
+  # Database-level filtering for simple value comparisons
+  defp add_filters(query, []), do: query |> preload_and_convert()
 
-        {value_node_name, comparator}
-        when is_atom(value_node_name) and
-               (comparator in [:is_nil, :is_not_nil] or is_function(comparator)) ->
-          value_node = find_value_by_name(execution, value_node_name)
-          value_node != nil and cmp(comparator).(value_node.node_value)
+  defp add_filters(query, value_filters) when is_list(value_filters) do
+    # Validate all filters are database-compatible before proceeding
+    Enum.each(value_filters, &validate_db_filter/1)
+
+    query
+    |> apply_db_value_filters(value_filters)
+    |> preload_and_convert()
+  end
+
+  # Validate filters are compatible with database-level filtering
+  defp validate_db_filter({node_name, op, value})
+       when is_atom(node_name) and op in [:eq, :neq, :lt, :lte, :gt, :gte, :in, :not_in] do
+    # Additional validation for the value type
+    if primitive_value?(value) do
+      :ok
+    else
+      raise ArgumentError,
+            "Unsupported value type for database filtering: #{inspect(value)}. " <>
+              "Only strings, numbers, booleans, nil, and lists of primitives are supported."
+    end
+  end
+
+  defp validate_db_filter({node_name, op})
+       when is_atom(node_name) and op in [:is_nil, :is_not_nil],
+       do: :ok
+
+  # Crash with clear error message for unsupported filters
+  defp validate_db_filter(filter) do
+    raise ArgumentError,
+          "Unsupported filter for database-level filtering: #{inspect(filter)}. " <>
+            "Only simple comparisons on strings, numbers, booleans, nil, and lists of primitives are supported. " <>
+            "Custom functions are not supported."
+  end
+
+  # Check if a value is a primitive type that can be handled at database level
+  defp primitive_value?(value) when is_binary(value) or is_number(value) or is_boolean(value) or is_nil(value),
+    do: true
+
+  defp primitive_value?(values) when is_list(values) do
+    Enum.all?(values, fn v -> is_binary(v) or is_number(v) or is_boolean(v) or is_nil(v) end)
+  end
+
+  defp primitive_value?(_), do: false
+
+  # Apply database-level value filtering using JOINs and JSONB queries
+  defp apply_db_value_filters(query, value_filters) do
+    # Split filters by type for different handling strategies
+    {existence_filters, comparison_filters} =
+      Enum.split_with(value_filters, fn
+        {_, op} when op in [:is_nil, :is_not_nil] -> true
+        _ -> false
       end)
+
+    # Apply comparison filters with JOINs (leveraging unique execution_id, node_name)
+    query_with_comparisons =
+      Enum.reduce(comparison_filters, query, fn {node_name, op, value}, acc_query ->
+        apply_comparison_filter(acc_query, node_name, op, value)
+      end)
+
+    # Apply existence filters using anti-join and inner join patterns
+    Enum.reduce(existence_filters, query_with_comparisons, fn {node_name, op}, acc_query ->
+      node_name_str = Atom.to_string(node_name)
+
+      case op do
+        :is_nil ->
+          from(e in acc_query,
+            left_join: v in Journey.Persistence.Schema.Execution.Value,
+            on: v.execution_id == e.id and v.node_name == ^node_name_str,
+            where: is_nil(v.id)
+          )
+
+        :is_not_nil ->
+          from(e in acc_query,
+            join: v in Journey.Persistence.Schema.Execution.Value,
+            on: v.execution_id == e.id and v.node_name == ^node_name_str
+          )
+      end
     end)
   end
 
-  defp cmp(:eq), do: fn a, b -> a == b end
-  defp cmp(:neq), do: fn a, b -> a != b end
-  defp cmp(:lt), do: fn a, b -> a < b end
-  defp cmp(:lte), do: fn a, b -> a <= b end
-  defp cmp(:gt), do: fn a, b -> a > b end
-  defp cmp(:gte), do: fn a, b -> a >= b end
-  defp cmp(:in), do: fn a, b -> a in b end
-  defp cmp(:not_in), do: fn a, b -> a not in b end
-  defp cmp(:is_nil), do: fn a -> is_nil(a) end
-  defp cmp(:is_not_nil), do: fn a -> not is_nil(a) end
-  defp cmp(f) when is_function(f), do: f
+  # Apply individual comparison filters with direct JSONB conditions
+  defp apply_comparison_filter(query, node_name, :eq, value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: v.node_value == ^value
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :neq, value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: v.node_value != ^value
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :lt, value) when is_number(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric < ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :lt, value) when is_binary(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'string' AND (? #>> '{}') < ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :lte, value) when is_number(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric <= ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :lte, value) when is_binary(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'string' AND (? #>> '{}') <= ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :gt, value) when is_number(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric > ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :gt, value) when is_binary(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'string' AND (? #>> '{}') > ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :gte, value) when is_number(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric >= ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :gte, value) when is_binary(value) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: fragment("jsonb_typeof(?) = 'string' AND (? #>> '{}') >= ?", v.node_value, v.node_value, ^value)
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :in, values) when is_list(values) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: v.node_value in ^values
+    )
+  end
+
+  defp apply_comparison_filter(query, node_name, :not_in, values) when is_list(values) do
+    from(e in query,
+      join: v in Journey.Persistence.Schema.Execution.Value,
+      on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
+      where: v.node_value not in ^values
+    )
+  end
+
+  # Helper to preload data and convert node names to atoms
+  defp preload_and_convert(query) do
+    from(e in query, preload: [:values, :computations])
+    |> Journey.Repo.all()
+    |> Enum.map(&convert_node_names_to_atoms/1)
+  end
 
   def find_value_by_name(execution, node_name) when is_atom(node_name) do
     execution.values |> Enum.find(fn value -> value.node_name == node_name end)

--- a/lib/journey/executions.ex
+++ b/lib/journey/executions.ex
@@ -836,7 +836,13 @@ defmodule Journey.Executions do
     from(e in query,
       join: v in Journey.Persistence.Schema.Execution.Value,
       on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
-      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric < ?", v.node_value, v.node_value, ^value)
+      where:
+        fragment(
+          "CASE WHEN jsonb_typeof(?) = 'number' THEN (?)::numeric < ? ELSE false END",
+          v.node_value,
+          v.node_value,
+          ^value
+        )
     )
   end
 
@@ -852,7 +858,13 @@ defmodule Journey.Executions do
     from(e in query,
       join: v in Journey.Persistence.Schema.Execution.Value,
       on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
-      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric <= ?", v.node_value, v.node_value, ^value)
+      where:
+        fragment(
+          "CASE WHEN jsonb_typeof(?) = 'number' THEN (?)::numeric <= ? ELSE false END",
+          v.node_value,
+          v.node_value,
+          ^value
+        )
     )
   end
 
@@ -868,7 +880,13 @@ defmodule Journey.Executions do
     from(e in query,
       join: v in Journey.Persistence.Schema.Execution.Value,
       on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
-      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric > ?", v.node_value, v.node_value, ^value)
+      where:
+        fragment(
+          "CASE WHEN jsonb_typeof(?) = 'number' THEN (?)::numeric > ? ELSE false END",
+          v.node_value,
+          v.node_value,
+          ^value
+        )
     )
   end
 
@@ -884,7 +902,13 @@ defmodule Journey.Executions do
     from(e in query,
       join: v in Journey.Persistence.Schema.Execution.Value,
       on: v.execution_id == e.id and v.node_name == ^Atom.to_string(node_name),
-      where: fragment("jsonb_typeof(?) = 'number' AND (?)::numeric >= ?", v.node_value, v.node_value, ^value)
+      where:
+        fragment(
+          "CASE WHEN jsonb_typeof(?) = 'number' THEN (?)::numeric >= ? ELSE false END",
+          v.node_value,
+          v.node_value,
+          ^value
+        )
     )
   end
 

--- a/priv/repo/migrations/20250827180830_add_unique_values_constraint.exs
+++ b/priv/repo/migrations/20250827180830_add_unique_values_constraint.exs
@@ -1,0 +1,11 @@
+defmodule Journey.Repo.Migrations.AddUniqueValuesConstraint do
+  use Ecto.Migration
+
+  def change do
+    # Add unique index on (execution_id, node_name) to enforce data integrity
+    # and optimize JOIN performance for value filtering queries
+    create unique_index(:values, [:execution_id, :node_name],
+             name: :values_execution_node_unique_idx
+           )
+  end
+end

--- a/test/journey/journey_list_executions_test.exs
+++ b/test/journey/journey_list_executions_test.exs
@@ -50,8 +50,7 @@ defmodule Journey.JourneyListExecutionsTest do
       some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, :in, [20, 22]}])
       assert Enum.count(some_executions) == 2
 
-      neq = fn node_value, val -> node_value != val end
-      some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, neq, 1}])
+      some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, :neq, 1}])
       assert Enum.count(some_executions) == 99
 
       some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, :is_not_nil}])
@@ -60,8 +59,7 @@ defmodule Journey.JourneyListExecutionsTest do
       some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, :is_nil}])
       assert some_executions == []
 
-      is_one = fn node_value -> node_value == 1 end
-      some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, is_one}])
+      some_executions = Journey.list_executions(graph_name: graph.name, value_filters: [{:first_name, :eq, 1}])
       assert Enum.count(some_executions) == 1
     end
 

--- a/test/journey/sql_injection_test.exs
+++ b/test/journey/sql_injection_test.exs
@@ -1,0 +1,239 @@
+defmodule Journey.SqlInjectionTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Node
+
+  describe "SQL injection protection in value filters" do
+    test "malicious string values are safely parameterized" do
+      graph =
+        Journey.new_graph(
+          "sql_injection_test_#{Journey.Helpers.Random.random_string()}",
+          "1.0.0",
+          [input(:test_field), input(:name)]
+        )
+
+      # Create some legitimate data
+      _exec1 = Journey.start_execution(graph) |> Journey.set_value(:test_field, 42) |> Journey.set_value(:name, "alice")
+      _exec2 = Journey.start_execution(graph) |> Journey.set_value(:test_field, 100) |> Journey.set_value(:name, "bob")
+
+      # Test various SQL injection attempts as filter values
+      malicious_payloads = [
+        # Classic SQL injection attempts
+        "'; DROP TABLE executions; --",
+        "' OR '1'='1",
+        "1; DELETE FROM values; --",
+        "42'; INSERT INTO executions (id) VALUES ('hacked'); --",
+
+        # JSONB-specific injection attempts
+        "{}'; DROP TABLE values; --",
+        "'::text; DELETE FROM executions; --",
+
+        # PostgreSQL function injection attempts
+        "pg_sleep(5)",
+        "version()",
+
+        # Mixed type confusion attempts
+        "42 OR 1=1",
+        "true'; DROP TABLE executions; --"
+      ]
+
+      # Test each malicious payload - all should be safely handled without SQL injection
+      for payload <- malicious_payloads do
+        # All string payloads should be safely parameterized (no crashes or injection)
+        result = Journey.list_executions(graph_name: graph.name, value_filters: [{:name, :eq, payload}])
+        assert is_list(result)
+        # Should find no matches for malicious strings
+        assert Enum.empty?(result)
+
+        # Numeric field with string payload should also be safely handled
+        result2 = Journey.list_executions(graph_name: graph.name, value_filters: [{:test_field, :gt, payload}])
+        assert is_list(result2)
+        # Should find no matches
+        assert Enum.empty?(result2)
+      end
+
+      # Test that complex objects are properly rejected
+      assert_raise ArgumentError, ~r/Unsupported value type/, fn ->
+        Journey.list_executions(graph_name: graph.name, value_filters: [{:name, :eq, %{evil: "payload"}}])
+      end
+    end
+
+    test "malicious node names are safely handled" do
+      graph =
+        Journey.new_graph(
+          "node_name_injection_test_#{Journey.Helpers.Random.random_string()}",
+          "1.0.0",
+          [input(:legitimate_field)]
+        )
+
+      _exec = Journey.start_execution(graph) |> Journey.set_value(:legitimate_field, "test_value")
+
+      # Test malicious node names - these should raise validation errors, not cause SQL injection
+      malicious_node_names = [
+        :"'; DROP TABLE executions; --",
+        :"test_field'; DELETE FROM values WHERE 1=1; --",
+        :"field OR 1=1"
+      ]
+
+      for malicious_node <- malicious_node_names do
+        # Malicious node names should be safely handled - return empty results, no SQL injection
+        result = Journey.list_executions(graph_name: graph.name, value_filters: [{malicious_node, :eq, "test"}])
+        assert is_list(result)
+        # Should find no matches for non-existent nodes
+        assert Enum.empty?(result)
+      end
+    end
+
+    test "malicious graph names are safely parameterized" do
+      # Test that malicious graph names don't cause SQL injection
+      malicious_graph_names = [
+        "'; DROP TABLE executions; SELECT * FROM executions WHERE graph_name = '",
+        "test' OR '1'='1' OR graph_name = '",
+        "test'; DELETE FROM executions; SELECT * FROM executions WHERE graph_name = '"
+      ]
+
+      for malicious_name <- malicious_graph_names do
+        # This should safely return empty results, not execute malicious SQL
+        result = Journey.list_executions(graph_name: malicious_name)
+        assert is_list(result)
+        assert Enum.empty?(result)
+      end
+    end
+
+    test "complex value filters with mixed malicious input" do
+      graph =
+        Journey.new_graph(
+          "complex_injection_test_#{Journey.Helpers.Random.random_string()}",
+          "1.0.0",
+          [input(:num_field), input(:str_field), input(:bool_field)]
+        )
+
+      # Create legitimate data
+      _exec =
+        Journey.start_execution(graph)
+        |> Journey.set_value(:num_field, 50)
+        |> Journey.set_value(:str_field, "normal_string")
+        |> Journey.set_value(:bool_field, true)
+
+      # Test multiple filters with malicious content - should be safely handled
+      result =
+        Journey.list_executions(
+          graph_name: graph.name,
+          value_filters: [
+            # legitimate
+            {:num_field, :gt, 30},
+            # malicious but safely parameterized
+            {:str_field, :eq, "'; DROP TABLE executions; --"},
+            # legitimate
+            {:bool_field, :eq, false}
+          ]
+        )
+
+      assert is_list(result)
+      # No matches for the malicious string
+      assert Enum.empty?(result)
+
+      # Test that unsupported data types are properly rejected
+      assert_raise ArgumentError, ~r/Unsupported value type/, fn ->
+        Journey.list_executions(
+          graph_name: graph.name,
+          value_filters: [
+            {:num_field, :gt, %{malicious: "object"}}
+          ]
+        )
+      end
+
+      # Test that legitimate complex filters work correctly
+      result =
+        Journey.list_executions(
+          graph_name: graph.name,
+          value_filters: [
+            {:num_field, :gte, 40},
+            {:str_field, :neq, "different_string"}
+          ]
+        )
+
+      assert is_list(result)
+      assert length(result) == 1
+    end
+
+    test "database state remains intact after injection attempts" do
+      # Verify that our database state is not corrupted by injection attempts
+      graph =
+        Journey.new_graph(
+          "integrity_test_#{Journey.Helpers.Random.random_string()}",
+          "1.0.0",
+          [input(:test_field)]
+        )
+
+      # Create some data
+      exec1 = Journey.start_execution(graph) |> Journey.set_value(:test_field, "before_injection")
+
+      # Count records before injection attempts
+      initial_executions = Journey.list_executions(graph_name: graph.name)
+      initial_count = length(initial_executions)
+
+      # Attempt various injections (should be safely handled)
+      injection_attempts = [
+        "'; DROP TABLE executions; --",
+        "'; DELETE FROM values; --",
+        "'; UPDATE executions SET archived_at = 1; --"
+      ]
+
+      for injection <- injection_attempts do
+        # These should not modify the database
+        result = Journey.list_executions(graph_name: graph.name, value_filters: [{:test_field, :eq, injection}])
+        assert is_list(result)
+      end
+
+      # Create more data after injection attempts
+      _exec2 = Journey.start_execution(graph) |> Journey.set_value(:test_field, "after_injection")
+
+      # Verify database integrity - should have original + new data
+      final_executions = Journey.list_executions(graph_name: graph.name)
+      assert length(final_executions) == initial_count + 1
+
+      # Verify our original data is still intact
+      reloaded_exec1 = Journey.load(exec1)
+      assert Journey.get_value(reloaded_exec1, :test_field) == {:ok, "before_injection"}
+    end
+
+    test "edge cases with special PostgreSQL characters" do
+      graph =
+        Journey.new_graph(
+          "special_chars_test_#{Journey.Helpers.Random.random_string()}",
+          "1.0.0",
+          [input(:text_field)]
+        )
+
+      # Create data with special PostgreSQL characters that need proper escaping
+      special_values = [
+        "text with 'single quotes'",
+        "text with \"double quotes\"",
+        "text with $$ dollar quotes $$",
+        "text with \\ backslashes \\",
+        "text with \n newlines \n",
+        "text with ; semicolons ;",
+        "text with -- comments --"
+      ]
+
+      # Create executions with special characters
+      for value <- special_values do
+        _exec = Journey.start_execution(graph) |> Journey.set_value(:text_field, value)
+      end
+
+      # Verify we can filter by these values safely
+      for value <- special_values do
+        result = Journey.list_executions(graph_name: graph.name, value_filters: [{:text_field, :eq, value}])
+        assert length(result) == 1
+
+        found_exec = hd(result)
+        assert Journey.get_value(found_exec, :text_field) == {:ok, value}
+      end
+
+      # Test string comparisons with special characters
+      result = Journey.list_executions(graph_name: graph.name, value_filters: [{:text_field, :lt, "text with zzz"}])
+      assert length(result) == length(special_values)
+    end
+  end
+end


### PR DESCRIPTION
1. Updating `Journey.list_executions` to use db-based value filtering (replacing the initial implementation where we used memory-based filtering.
2. adding a test to check against sql injection vulnerabilities,
3. adding uniqueness constrain to `values`, for execution id + name  