### PR TITLE
adding `Journey.get()` (which also returns the value's revision), soft-deprecating `get_value()`

### DIFF
--- a/lib/journey/helpers/random.ex
+++ b/lib/journey/helpers/random.ex
@@ -14,6 +14,11 @@ defmodule Journey.Helpers.Random do
     Nanoid.generate(length, dictionary)
   end
 
+  def random_string_w_time(length \\ 12, dictionary \\ any_char_or_digit())
+      when is_number(length) and is_binary(dictionary) do
+    random_string(length, dictionary) <> "#{System.system_time(:microsecond)}"
+  end
+
   def object_id(prefix) when is_binary(prefix) do
     prefix <> random_string(20, digits() <> uppercase())
   end

--- a/lib/journey/node.ex
+++ b/lib/journey/node.ex
@@ -92,8 +92,8 @@ defmodule Journey.Node do
   ...>       ]
   ...>     )
   iex> execution = graph |> Journey.start_execution() |> Journey.set(:name, "Alice")
-  iex> execution |> Journey.get_value(:pig_latin_ish_name, wait: :any)
-  {:ok, "Alice-ay"}
+  iex> execution |> Journey.get(:pig_latin_ish_name, wait: :any)
+  {:ok, "Alice-ay", 3}
   iex> execution |> Journey.values() |> redact([:execution_id, :last_updated_at])
   %{name: "Alice", pig_latin_ish_name: "Alice-ay", execution_id: "...", last_updated_at: 1_234_567_890}
   ```
@@ -119,11 +119,11 @@ defmodule Journey.Node do
   ...>     )
   iex> execution = graph |> Journey.start_execution()
   iex> execution = Journey.set(execution, :temperature, 25)
-  iex> Journey.get_value(execution, :high_temp_alert)
+  iex> Journey.get(execution, :high_temp_alert)
   {:error, :not_set}
   iex> execution = Journey.set(execution, :temperature, 35)
-  iex> Journey.get_value(execution, :high_temp_alert, wait: :any)
-  {:ok, "High temperature alert: 35°C"}
+  iex> Journey.get(execution, :high_temp_alert, wait: :any)
+  {:ok, "High temperature alert: 35°C", 4}
   ```
 
   ## Return Values
@@ -171,8 +171,8 @@ defmodule Journey.Node do
   ...>     graph
   ...>     |> Journey.start_execution()
   ...>     |> Journey.set(:name, "Mario")
-  iex> execution |> Journey.get_value(:remove_pii, wait: :any)
-  {:ok, "updated :name"}
+  iex> execution |> Journey.get(:remove_pii, wait: :any)
+  {:ok, "updated :name", 3}
   iex> execution |> Journey.values() |> redact([:execution_id, :last_updated_at])
   %{name: "redacted", remove_pii: "updated :name",  execution_id: "...", last_updated_at: 1_234_567_890}
   ```
@@ -215,7 +215,7 @@ defmodule Journey.Node do
   iex> execution.archived_at == nil
   true
   iex> execution = Journey.set(execution, :name, "Mario")
-  iex> {:ok, _} = Journey.get_value(execution, :archive, wait: :any)
+  iex> {:ok, _, _} = Journey.get(execution, :archive, wait: :any)
   iex> Journey.load(execution)
   nil
   iex> execution = Journey.load(execution, include_archived: true)
@@ -267,12 +267,12 @@ defmodule Journey.Node do
   ...>     )
   iex> execution = graph |> Journey.start_execution()
   iex> execution = Journey.set(execution, :content, "First version")
-  iex> {:ok, history1} = Journey.get_value(execution, :content_history, wait: :any)
+  iex> {:ok, history1, _} = Journey.get(execution, :content_history, wait: :any)
   iex> length(history1)
   1
   iex> [%{"value" => "First version", "node" => "content", "timestamp" => _ts}] = history1
   iex> execution = Journey.set(execution, :content, "Second version")
-  iex> {:ok, history2} = Journey.get_value(execution, :content_history, wait: :newer)
+  iex> {:ok, history2, _} = Journey.get(execution, :content_history, wait: :newer)
   iex> length(history2)
   2
   iex> [_, %{"value" => "Second version", "node" => "content", "timestamp" => _ts}] = history2
@@ -292,14 +292,19 @@ defmodule Journey.Node do
   ...>     )
   iex> execution = graph |> Journey.start_execution()
   iex> execution = Journey.set(execution, :status, "pending")
+  iex> {:ok, history, rev1} = Journey.get(execution, :status_history, wait: :any)
+  iex> Enum.map(history, fn entry -> entry["value"] end)
+  ["pending"]
   iex> execution = Journey.set(execution, :status, "active")
+  iex> {:ok, history, rev2} = Journey.get(execution, :status_history, wait: {:newer_than, rev1})
+  iex> Enum.map(history, fn entry -> entry["value"] end)
+  ["pending", "active"]
   iex> execution = Journey.set(execution, :status, "completed")
-  iex> {:ok, history} = Journey.get_value(execution, :status_history, wait: :newer)
-  iex> length(history)
-  2
-  iex> # Should keep the last 2 entries due to max_entries: 2
+  iex> {:ok, history, _rev} = Journey.get(execution, :status_history, wait: {:newer_than, rev2})
+  iex> # Since status_history is limited to `max_entries: 2`, we'll only see the 2 latest values.
   iex> Enum.map(history, fn entry -> entry["value"] end)
   ["active", "completed"]
+
   ```
 
   With unlimited history:
@@ -317,7 +322,7 @@ defmodule Journey.Node do
   ...>     )
   iex> execution = graph |> Journey.start_execution()
   iex> execution = Journey.set(execution, :audit_event, "login")
-  iex> {:ok, history} = Journey.get_value(execution, :audit_log, wait: :any)
+  iex> {:ok, history, _} = Journey.get(execution, :audit_log, wait: :any)
   iex> length(history)
   1
   iex> [%{"value" => "login", "node" => "audit_event", "timestamp" => _ts}] = history
@@ -431,8 +436,7 @@ defmodule Journey.Node do
   "Mario"
   iex> # This is only needed in a test, to simulate the background processing that happens in non-tests automatically.
   iex> background_sweeps_task = Journey.Scheduler.Background.Periodic.start_background_sweeps_in_test(execution.id)
-  iex> execution |> Journey.get_value(:nap_time, wait: :any)
-  {:ok, "It's time to take a nap, Mario!"}
+  iex> {:ok, "It's time to take a nap, Mario!", _revision} = execution |> Journey.get(:nap_time, wait: :any)
   iex> Journey.Scheduler.Background.Periodic.stop_background_sweeps_in_test(background_sweeps_task)
 
   ```
@@ -499,16 +503,16 @@ defmodule Journey.Node do
   iex> # This is only needed in a test, to simulate the background processing that happens in non-tests automatically.
   iex> background_sweeps_task = Journey.Scheduler.Background.Periodic.start_background_sweeps_in_test(execution.id)
   iex> # Wait for initial reminders
-  iex> {:ok, count1} = Journey.get_value(execution, :send_a_reminder, wait: :any)
+  iex> {:ok, count1, _} = Journey.get(execution, :send_a_reminder, wait: :any)
   iex> count1 >= 1
   true
   iex> # Wait for more reminders to verify recurring behavior
   iex> execution = Journey.load(execution)
-  iex> {:ok, count2} = Journey.get_value(execution, :send_a_reminder, wait: :newer)
+  iex> {:ok, count2, _} = Journey.get(execution, :send_a_reminder, wait: :newer)
   iex> count2 > count1
   true
   iex> execution = Journey.load(execution)
-  iex> {:ok, count3} = Journey.get_value(execution, :send_a_reminder, wait: :newer)
+  iex> {:ok, count3, _} = Journey.get(execution, :send_a_reminder, wait: :newer)
   iex> count3 > count2
   true
   iex> Journey.Scheduler.Background.Periodic.stop_background_sweeps_in_test(background_sweeps_task)

--- a/test/journey/get_test.exs
+++ b/test/journey/get_test.exs
@@ -1,0 +1,466 @@
+defmodule Journey.GetTest do
+  use ExUnit.Case, async: true
+
+  import Journey.Node
+
+  import Journey.Scheduler.Background.Periodic,
+    only: [start_background_sweeps_in_test: 1, stop_background_sweeps_in_test: 1]
+
+  describe "Journey.get/3" do
+    test "returns value and revision for set input node" do
+      graph = Journey.Test.Support.create_test_graph1()
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:user_name, "Alice")
+
+      {:ok, value, revision} = Journey.get(execution, :user_name)
+      assert value == "Alice"
+      assert is_integer(revision)
+      assert revision > 0
+    end
+
+    test "returns error for unset node with immediate wait" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      assert {:error, :not_set} = Journey.get(execution, :user_name)
+    end
+
+    test "waits for computed value with wait: :any" do
+      graph = Journey.Test.Support.create_test_graph1()
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:user_name, "Bob")
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      {:ok, value, revision} = Journey.get(execution, :reminder, wait: :any)
+      assert value =~ "Bob"
+      assert is_integer(revision)
+      assert revision > 0
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "waits for newer revision with wait: {:newer_than, revision}" do
+      graph = Journey.Test.Support.create_test_graph1()
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:user_name, "Carol")
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Get initial value and revision
+      {:ok, initial_value, initial_revision} = Journey.get(execution, :reminder, wait: :any)
+      assert initial_value =~ "Carol"
+      assert is_integer(initial_revision)
+
+      # Trigger recomputation
+      execution = Journey.set(execution, :user_name, "Dave")
+
+      # Wait for newer revision
+      {:ok, new_value, new_revision} = Journey.get(execution, :reminder, wait: {:newer_than, initial_revision})
+      assert new_value =~ "Dave"
+      assert new_revision > initial_revision
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "waits for newer revision with wait: :newer" do
+      graph = Journey.Test.Support.create_test_graph1()
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:user_name, "Eve")
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Get initial value
+      {:ok, _, initial_revision} = Journey.get(execution, :reminder, wait: :any)
+
+      # Update the input to trigger recomputation
+      execution = Journey.set(execution, :user_name, "Frank")
+
+      # Wait for newer revision
+      {:ok, new_value, new_revision} = Journey.get(execution, :reminder, wait: :newer)
+      assert new_value =~ "Frank"
+      assert new_revision > initial_revision
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "respects timeout option" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      # Should timeout quickly when waiting for unset value
+      assert {:error, :not_set} = Journey.get(execution, :user_name, wait: :any, timeout: 100)
+    end
+
+    test "works with infinity timeout" do
+      graph = Journey.Test.Support.create_test_graph1()
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:user_name, "Grace")
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      {:ok, value, revision} = Journey.get(execution, :reminder, wait: :any, timeout: :infinity)
+      assert value =~ "Grace"
+      assert is_integer(revision)
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "returns error for computation failure" do
+      graph = create_failing_graph()
+      execution = Journey.start_execution(graph)
+      execution = Journey.set(execution, :will_fail, true)
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      assert {:error, :computation_failed} = Journey.get(execution, :result, wait: :any)
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "raises error for unknown node" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      assert_raise RuntimeError, fn ->
+        Journey.get(execution, :unknown_node)
+      end
+    end
+
+    test "revision matches value atomically - no race condition" do
+      graph = Journey.Test.Support.create_test_graph1()
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:user_name, "Henry")
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Get value and revision atomically
+      {:ok, value, revision} = Journey.get(execution, :reminder, wait: :any)
+
+      # Reload execution and verify the revision matches the value we got
+      reloaded = Journey.load(execution.id)
+      reminder_value_record = Enum.find(reloaded.values, fn v -> v.node_name == :reminder end)
+
+      assert reminder_value_record.node_value == value
+      assert reminder_value_record.ex_revision == revision
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "validates option keys" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      assert_raise ArgumentError, fn ->
+        Journey.get(execution, :user_name, invalid_option: true)
+      end
+    end
+
+    test "validates wait option values" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      assert_raise ArgumentError, fn ->
+        Journey.get(execution, :user_name, wait: :invalid_wait_option)
+      end
+    end
+  end
+
+  describe "Journey.get/3 - comprehensive value types" do
+    test "handles different value types with correct revisions" do
+      graph = create_multi_type_graph()
+      execution = Journey.start_execution(graph)
+
+      # Test string value
+      execution = Journey.set(execution, :string_val, "hello world")
+      {:ok, "hello world", rev1} = Journey.get(execution, :string_val)
+      assert is_integer(rev1) and rev1 > 0
+
+      # Test number value
+      execution = Journey.set(execution, :number_val, 42)
+      {:ok, 42, rev2} = Journey.get(execution, :number_val)
+      assert rev2 > rev1
+
+      # Test boolean value
+      execution = Journey.set(execution, :bool_val, true)
+      {:ok, true, rev3} = Journey.get(execution, :bool_val)
+      assert rev3 > rev2
+
+      # Test map value (note: atom keys get converted to strings)
+      map_val = %{"key" => "value", "count" => 5}
+      execution = Journey.set(execution, :map_val, map_val)
+      {:ok, returned_map, rev4} = Journey.get(execution, :map_val)
+      assert returned_map == map_val
+      assert rev4 > rev3
+
+      # Test list value (note: maps in lists also get atom keys converted)
+      list_val = [1, 2, "three", %{"four" => 4}]
+      execution = Journey.set(execution, :list_val, list_val)
+      {:ok, returned_list, rev5} = Journey.get(execution, :list_val)
+      assert returned_list == list_val
+      assert rev5 > rev4
+
+      # Test nil value
+      execution = Journey.set(execution, :nil_val, nil)
+      {:ok, nil, rev6} = Journey.get(execution, :nil_val)
+      assert rev6 > rev5
+    end
+  end
+
+  describe "Journey.get/3 - edge cases and error conditions" do
+    test "validates timeout option values" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      # Invalid timeout - string
+      assert_raise ArgumentError, ~r/Invalid timeout value/, fn ->
+        Journey.get(execution, :user_name, wait: :any, timeout: "invalid")
+      end
+
+      # Invalid timeout - negative number
+      assert_raise ArgumentError, ~r/Invalid timeout value/, fn ->
+        Journey.get(execution, :user_name, wait: :any, timeout: -100)
+      end
+
+      # Invalid timeout - zero
+      assert_raise ArgumentError, ~r/Invalid timeout value/, fn ->
+        Journey.get(execution, :user_name, wait: :any, timeout: 0)
+      end
+    end
+
+    test "validates wait option with newer_than requires integer" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      assert_raise ArgumentError, ~r/Invalid :wait option/, fn ->
+        Journey.get(execution, :user_name, wait: {:newer_than, "not_integer"})
+      end
+
+      assert_raise ArgumentError, ~r/Invalid :wait option/, fn ->
+        Journey.get(execution, :user_name, wait: {:newer_than, 1.5})
+      end
+    end
+
+    test "validates wait option combinations" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      # Invalid wait option types
+      assert_raise ArgumentError, ~r/Invalid :wait option/, fn ->
+        Journey.get(execution, :user_name, wait: "invalid")
+      end
+
+      assert_raise ArgumentError, ~r/Invalid :wait option/, fn ->
+        Journey.get(execution, :user_name, wait: [:invalid, :list])
+      end
+    end
+
+    test "raises error for non-existent node with detailed message" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      assert_raise RuntimeError, ~r/'.*unknown_node.*' is not a known node/, fn ->
+        Journey.get(execution, :unknown_node)
+      end
+    end
+  end
+
+  describe "Journey.get/3 - wait modes comprehensive" do
+    test "wait: :immediate returns immediately for all states" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      # Unset node - immediate return
+      assert {:error, :not_set} = Journey.get(execution, :user_name, wait: :immediate)
+
+      # Set node - immediate return
+      execution = Journey.set(execution, :user_name, "Alice")
+      {:ok, "Alice", _} = Journey.get(execution, :user_name, wait: :immediate)
+    end
+
+    test "wait: :any with different timeout values" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      # Short timeout for unset value
+      assert {:error, :not_set} = Journey.get(execution, :user_name, wait: :any, timeout: 50)
+
+      # Longer timeout with value set in background
+      Task.async(fn ->
+        Process.sleep(100)
+        Journey.set(execution, :user_name, "Bob")
+      end)
+
+      {:ok, "Bob", _} = Journey.get(execution, :user_name, wait: :any, timeout: 500)
+    end
+
+    test "wait: :newer works correctly for immediate updates" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+      execution = Journey.set(execution, :user_name, "Alice")
+
+      # Update value in background
+      Task.async(fn ->
+        Process.sleep(50)
+        Journey.set(execution, :user_name, "Bob")
+      end)
+
+      {:ok, "Bob", _} = Journey.get(execution, :user_name, wait: :newer, timeout: 300)
+    end
+
+    test "wait: {:newer_than, revision} with specific revision numbers" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      execution = Journey.set(execution, :user_name, "Alice")
+      {:ok, _, rev1} = Journey.get(execution, :user_name)
+
+      execution = Journey.set(execution, :user_name, "Bob")
+      {:ok, _, _rev2} = Journey.get(execution, :user_name)
+
+      execution = Journey.set(execution, :user_name, "Carol")
+
+      # Should get Carol since revision will be > rev1
+      {:ok, "Carol", rev3} = Journey.get(execution, :user_name, wait: {:newer_than, rev1})
+      assert rev3 > rev1
+
+      # Should timeout since no revision > rev3 exists
+      assert {:error, :not_set} = Journey.get(execution, :user_name, wait: {:newer_than, rev3}, timeout: 100)
+    end
+  end
+
+  describe "Journey.get/3 - revision atomicity and consistency" do
+    test "multiple gets return consistent revision for same value" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+      execution = Journey.set(execution, :user_name, "Alice")
+
+      {:ok, "Alice", rev1} = Journey.get(execution, :user_name)
+      {:ok, "Alice", rev2} = Journey.get(execution, :user_name)
+      {:ok, "Alice", rev3} = Journey.get(execution, :user_name)
+
+      assert rev1 == rev2
+      assert rev2 == rev3
+    end
+
+    test "revision increments correctly with value changes" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+
+      execution = Journey.set(execution, :user_name, "Alice")
+      {:ok, "Alice", rev1} = Journey.get(execution, :user_name)
+
+      execution = Journey.set(execution, :user_name, "Bob")
+      {:ok, "Bob", rev2} = Journey.get(execution, :user_name)
+
+      execution = Journey.set(execution, :user_name, "Carol")
+      {:ok, "Carol", rev3} = Journey.get(execution, :user_name)
+
+      assert rev2 > rev1
+      assert rev3 > rev2
+    end
+
+    test "computed values have correct revisions" do
+      graph = Journey.Test.Support.create_test_graph1()
+      execution = Journey.start_execution(graph)
+      execution = Journey.set(execution, :user_name, "Alice")
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      {:ok, greeting_value, greeting_rev} = Journey.get(execution, :greeting, wait: :any)
+      {:ok, _user_value, user_rev} = Journey.get(execution, :user_name)
+
+      assert greeting_value == "Hello, Alice"
+      assert is_integer(greeting_rev)
+      assert greeting_rev >= user_rev
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+  end
+
+  describe "Journey.get/3 - failed computations" do
+    test "returns computation_failed for permanently failed nodes" do
+      graph = create_failing_graph()
+      execution = Journey.start_execution(graph)
+      execution = Journey.set(execution, :will_fail, true)
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Should return computation_failed after retries are exhausted
+      assert {:error, :computation_failed} = Journey.get(execution, :result, wait: :any)
+
+      # Subsequent calls should return immediately
+      assert {:error, :computation_failed} = Journey.get(execution, :result, wait: :immediate)
+      assert {:error, :computation_failed} = Journey.get(execution, :result)
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+
+    test "failed computation returns computation_failed consistently" do
+      graph = create_failing_graph()
+      execution = Journey.start_execution(graph)
+      execution = Journey.set(execution, :will_fail, true)
+
+      background_sweeps_task = start_background_sweeps_in_test(execution.id)
+
+      # Wait for the computation to fail
+      assert {:error, :computation_failed} = Journey.get(execution, :result, wait: :any)
+
+      # Subsequent calls should consistently return the same error
+      assert {:error, :computation_failed} = Journey.get(execution, :result, wait: :immediate)
+      assert {:error, :computation_failed} = Journey.get(execution, :result)
+
+      stop_background_sweeps_in_test(background_sweeps_task)
+    end
+  end
+
+  # Helper functions
+  defp create_multi_type_graph do
+    Journey.new_graph(
+      "multi type test graph #{__MODULE__}",
+      "1.0.0",
+      [
+        input(:string_val),
+        input(:number_val),
+        input(:bool_val),
+        input(:map_val),
+        input(:list_val),
+        input(:nil_val)
+      ]
+    )
+  end
+
+  defp create_failing_graph do
+    Journey.new_graph(
+      "failing computation test graph #{__MODULE__}",
+      "1.0.0",
+      [
+        input(:will_fail),
+        compute(
+          :result,
+          [:will_fail],
+          fn %{will_fail: should_fail} ->
+            if should_fail do
+              {:error, "intentional test failure"}
+            else
+              {:ok, "success"}
+            end
+          end,
+          max_retries: 1
+        )
+      ]
+    )
+  end
+end

--- a/test/journey/get_value_test.exs
+++ b/test/journey/get_value_test.exs
@@ -13,7 +13,7 @@ defmodule Journey.JourneyGetValueTest do
         basic_graph(random_string())
         |> Journey.start_execution()
 
-      assert Journey.get_value(execution, :first_name) == {:error, :not_set}
+      assert Journey.get(execution, :first_name) == {:error, :not_set}
     end
 
     test "sunny day, input, set, non-blocking" do
@@ -22,7 +22,7 @@ defmodule Journey.JourneyGetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :first_name) == {:ok, "Mario"}
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
     end
 
     test "sunny day, computation, set, blocking" do
@@ -31,7 +31,7 @@ defmodule Journey.JourneyGetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :greeting, wait_any: true) == {:ok, "Hello, Mario"}
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
     end
 
     test "no such node" do
@@ -43,7 +43,7 @@ defmodule Journey.JourneyGetValueTest do
       assert_raise RuntimeError,
                    "':no_such_node' is not a known node in execution '#{execution.id}' / graph '#{execution.graph_name}'. Valid node names: [:execution_id, :first_name, :greeting, :last_updated_at].",
                    fn ->
-                     Journey.get_value(execution, :no_such_node, wait_any: true) == {:ok, "Hello, Mario"}
+                     Journey.get(execution, :no_such_node, wait: :any)
                    end
     end
   end

--- a/test/journey/list_executions_test.exs
+++ b/test/journey/list_executions_test.exs
@@ -100,7 +100,7 @@ defmodule Journey.JourneyListExecutionsTest do
         |> Journey.set(:first_name, "Mario")
 
       expected_order = remaining_ids ++ [first_id]
-      {:ok, "Hello, Mario"} = Journey.get_value(updated_execution, :greeting, wait_any: true)
+      {:ok, "Hello, Mario", _} = Journey.get(updated_execution, :greeting, wait: :any)
 
       listed_execution_ids =
         Journey.list_executions(graph_name: basic_graph(test_id).name, order_by_execution_fields: [:updated_at])

--- a/test/journey/node/archive_test.exs
+++ b/test/journey/node/archive_test.exs
@@ -31,8 +31,8 @@ defmodule Journey.Node.ArchiveTest do
 
       assert execution.archived_at == nil
       execution = Journey.set(execution, :user_name, "John Doe")
-      assert {:ok, "Hello, John Doe"} = Journey.get_value(execution, :greeting, wait_any: true)
-      {:ok, _a} = Journey.get_value(execution, :archival, wait_any: true)
+      {:ok, "Hello, John Doe", _} = Journey.get(execution, :greeting, wait: :any)
+      {:ok, _a, _} = Journey.get(execution, :archival, wait: :any)
 
       # The execution is now archived, and it is no longer visible by default.
       assert nil == execution |> Journey.load(), "archived executions are not load'able by default"

--- a/test/journey/node/conditions_test.exs
+++ b/test/journey/node/conditions_test.exs
@@ -27,11 +27,11 @@ defmodule Journey.Node.ConditionsTest do
 
       execution = Journey.start_execution(graph)
       execution = Journey.set(execution, :it_will_rain_tomorrow, false)
-      assert {:ok, "prepare my bike!"} = Journey.get_value(execution, :prepare_bike, wait_any: true)
+      {:ok, "prepare my bike!", _} = Journey.get(execution, :prepare_bike, wait: :any)
       assert Journey.values(execution) |> redact() == %{it_will_rain_tomorrow: false, prepare_bike: "prepare my bike!"}
 
       execution = Journey.set(execution, :it_will_rain_tomorrow, true)
-      assert {:ok, "prepare my umbrella!"} = Journey.get_value(execution, :prepare_umbrella, wait_any: true)
+      {:ok, "prepare my umbrella!", _} = Journey.get(execution, :prepare_umbrella, wait: :any)
 
       assert Journey.values(execution) |> redact() == %{
                it_will_rain_tomorrow: true,

--- a/test/journey/scheduler/background/sweeps/stalled_executions_test.exs
+++ b/test/journey/scheduler/background/sweeps/stalled_executions_test.exs
@@ -141,8 +141,8 @@ defmodule Journey.Scheduler.Background.Sweeps.StalledExecutionsTest do
         assert sweep_run_id != nil
 
         # Wait for computation to complete using wait_any
-        result = Journey.get_value(execution, :computed_result, wait_any: true)
-        assert result == {:ok, "computed: test_input"}
+        {:ok, result, _} = Journey.get(execution, :computed_result, wait: :any)
+        assert result == "computed: test_input"
       after
         Application.put_env(:journey, :stalled_executions_sweep, original_config)
       end

--- a/test/journey/scheduler/mutate_test.exs
+++ b/test/journey/scheduler/mutate_test.exs
@@ -10,7 +10,7 @@ defmodule Journey.Scheduler.Scheduler.MutateTest do
       graph = graph_v0()
       execution = graph |> Journey.start_execution()
 
-      assert Journey.get_value(execution, :switch_position) == {:error, :not_set}
+      assert Journey.get(execution, :switch_position) == {:error, :not_set}
       assert Journey.Executions.find_value_by_name(execution, :switch_position).ex_revision == 0
 
       execution = execution |> Journey.set(:switch_position, "on")
@@ -55,6 +55,11 @@ defmodule Journey.Scheduler.Scheduler.MutateTest do
              expected_next_revision == Journey.Executions.find_value_by_name(execution, :switch_position).ex_revision
            end)
 
-    assert wait_for(fn -> {:ok, "off"} == Journey.get_value(execution, :switch_position) end)
+    assert wait_for(fn ->
+             case Journey.get(execution, :switch_position) do
+               {:ok, "off", _} -> true
+               _ -> false
+             end
+           end)
   end
 end

--- a/test/journey/scheduler/on_save_test.exs
+++ b/test/journey/scheduler/on_save_test.exs
@@ -13,7 +13,7 @@ defmodule Journey.Scheduler.Scheduler.OnSaveTest do
     {_result, log} =
       with_log(fn ->
         execution = execution |> Journey.set(:user_name, "Mario")
-        assert Journey.get_value(execution, :greeting, wait_any: true) == {:ok, "Hello, Mario"}
+        {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
         Process.sleep(2000)
       end)
 

--- a/test/journey/scheduler/recompute_test.exs
+++ b/test/journey/scheduler/recompute_test.exs
@@ -10,7 +10,7 @@ defmodule Journey.Scheduler.Scheduler.RecomputeTest do
 
     execution = execution |> Journey.set(:user_name, "Mario")
     execution = execution |> Journey.set(:actual_name, "Bowser")
-    assert Journey.get_value(execution, :greeting, wait_any: true) == {:ok, "Hello, Mario"}
+    {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
     assert Journey.values(execution) |> redact([:execution_id, :last_updated_at]) == %{
              greeting: "Hello, Mario",
@@ -24,7 +24,7 @@ defmodule Journey.Scheduler.Scheduler.RecomputeTest do
     execution = execution |> Journey.set(:user_name, "Toad")
 
     # The graph is recomputed.
-    assert Journey.get_value(execution, :greeting, wait_new: true) == {:ok, "Hello, Toad"}
+    {:ok, "Hello, Toad", _} = Journey.get(execution, :greeting, wait: :newer)
 
     assert Journey.values(execution) |> redact([:execution_id, :last_updated_at]) == %{
              user_name: "Toad",

--- a/test/journey/scheduler/schedule_recurring_test.exs
+++ b/test/journey/scheduler/schedule_recurring_test.exs
@@ -33,7 +33,7 @@ defmodule Journey.Scheduler.Scheduler.ScheduleRecurringTest do
     expected_scheduled_time = System.system_time(:second) + 10
     execution = execution |> Journey.set(:keep_sending_reminders, true)
 
-    {:ok, original_scheduled_time} = Journey.get_value(execution, :schedule_a_reminder, wait_any: true)
+    {:ok, original_scheduled_time, _} = Journey.get(execution, :schedule_a_reminder, wait: :any)
 
     assert original_scheduled_time in (expected_scheduled_time - 1)..(expected_scheduled_time + 5)
 

--- a/test/journey/set_value_test.exs
+++ b/test/journey/set_value_test.exs
@@ -14,7 +14,7 @@ defmodule Journey.JourneySetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :first_name) == {:ok, "Mario"}
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
     end
 
     test "setting value to the same value" do
@@ -23,14 +23,14 @@ defmodule Journey.JourneySetValueTest do
         |> Journey.start_execution()
 
       execution_v1 |> Journey.set(:first_name, "Mario")
-      {:ok, "Mario"} = Journey.get_value(execution_v1, :first_name, wait_any: true)
-      {:ok, "Hello, Mario"} = Journey.get_value(execution_v1, :greeting, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution_v1, :first_name, wait: :any)
+      {:ok, "Hello, Mario", _} = Journey.get(execution_v1, :greeting, wait: :any)
       execution_after_first_set = execution_v1 |> Journey.load()
 
       assert execution_after_first_set.revision > execution_v1.revision
 
       execution_v1 |> Journey.set(:first_name, "Mario")
-      {:ok, "Mario"} = Journey.get_value(execution_v1, :first_name, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution_v1, :first_name, wait: :any)
       execution_after_second_set = execution_v1 |> Journey.load()
       assert execution_after_second_set.revision == execution_after_first_set.revision
     end
@@ -41,13 +41,13 @@ defmodule Journey.JourneySetValueTest do
         |> Journey.start_execution()
 
       execution_v2 = execution_v1 |> Journey.set(:first_name, "Mario")
-      {:ok, "Mario"} = Journey.get_value(execution_v1, :first_name, wait_any: true)
-      {:ok, "Hello, Mario"} = Journey.get_value(execution_v1, :greeting, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution_v1, :first_name, wait: :any)
+      {:ok, "Hello, Mario", _} = Journey.get(execution_v1, :greeting, wait: :any)
       assert execution_v2.revision > execution_v1.revision
 
       execution_v3 = execution_v1 |> Journey.set(:first_name, "Luigi")
-      {:ok, "Luigi"} = Journey.get_value(execution_v3, :first_name)
-      {:ok, "Hello, Luigi"} = Journey.get_value(execution_v3, :greeting, wait_new: true)
+      {:ok, "Luigi", _} = Journey.get(execution_v3, :first_name)
+      {:ok, "Hello, Luigi", _} = Journey.get(execution_v3, :greeting, wait: :newer)
       assert execution_v3.revision > execution_v2.revision
     end
 
@@ -62,8 +62,8 @@ defmodule Journey.JourneySetValueTest do
         execution
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :first_name) == {:ok, "Mario"}
-      {:ok, greeting} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
+      {:ok, greeting, _} = Journey.get(execution, :greeting, wait: :any)
       assert greeting == "Hello, Mario"
 
       execution = execution |> Journey.load()
@@ -118,7 +118,7 @@ defmodule Journey.JourneySetValueTest do
         |> Journey.start_execution()
 
       updated_execution = Journey.set(execution.id, :first_name, "Mario")
-      assert Journey.get_value(updated_execution, :first_name) == {:ok, "Mario"}
+      {:ok, "Mario", _} = Journey.get(updated_execution, :first_name)
     end
 
     test "atom values are rejected" do

--- a/test/journey/tools_test.exs
+++ b/test/journey/tools_test.exs
@@ -50,7 +50,7 @@ defmodule Journey.ToolsTest do
 
       background_sweeps_task = start_background_sweeps_in_test(execution.id)
 
-      {:ok, _} = Journey.get_value(execution, :reminder, wait_any: true)
+      {:ok, _, _} = Journey.get(execution, :reminder, wait: :any)
 
       summary_data = Journey.Tools.summarize_as_data(execution.id)
 
@@ -142,7 +142,7 @@ defmodule Journey.ToolsTest do
 
       background_sweeps_task = start_background_sweeps_in_test(execution.id)
 
-      {:ok, _} = Journey.get_value(execution, :reminder, wait_any: true)
+      {:ok, _, _} = Journey.get(execution, :reminder, wait: :any)
 
       result = Journey.Tools.summarize_as_text(execution.id)
 
@@ -242,9 +242,9 @@ defmodule Journey.ToolsTest do
       background_sweeps_task = start_background_sweeps_in_test(execution.id)
 
       # Get values to trigger computations
-      {:ok, _} = Journey.get_value(execution, :success_node, wait: :any)
+      {:ok, _, _} = Journey.get(execution, :success_node, wait: :any)
       # The fail_node will fail
-      {:error, _} = Journey.get_value(execution, :fail_node, wait: :newer)
+      {:error, _} = Journey.get(execution, :fail_node, wait: :newer)
 
       # Check that completed states use emoji format
       _execution_after = Journey.load(execution.id)
@@ -331,8 +331,8 @@ defmodule Journey.ToolsTest do
 
       # Wait for the immediately unblocked computations to complete
       # This ensures deterministic test output
-      {:ok, _} = Journey.get_value(execution, :send_reminder, wait_any: true)
-      {:ok, _} = Journey.get_value(execution, :send_follow_up, wait_any: true)
+      {:ok, _, _} = Journey.get(execution, :send_reminder, wait: :any)
+      {:ok, _, _} = Journey.get(execution, :send_follow_up, wait: :any)
 
       result = Journey.Tools.summarize_as_text(execution.id)
 
@@ -567,18 +567,13 @@ defmodule Journey.ToolsTest do
 
       background_sweeps_task = start_background_sweeps_in_test(execution.id)
 
-      {:ok, _} = Journey.get_value(execution, :reminder, wait_any: true)
+      {:ok, _, reminder_revision_1} = Journey.get(execution, :reminder, wait: :any)
       execution = execution |> Journey.load()
-
-      reminder_revision_1 =
-        execution.values
-        |> Enum.find(fn n -> n.node_name == :reminder end)
-        |> Map.get(:ex_revision)
 
       assert execution.revision == 7
 
       Journey.Tools.increment_revision(execution.id, :user_name)
-      {:ok, _} = Journey.get_value(execution, :reminder, wait: {:newer_than, reminder_revision_1})
+      {:ok, _, _} = Journey.get(execution, :reminder, wait: {:newer_than, reminder_revision_1})
       execution = execution |> Journey.load()
       assert execution.revision == 14
 
@@ -619,7 +614,7 @@ defmodule Journey.ToolsTest do
 
       background_sweeps_task = start_background_sweeps_in_test(execution.id)
 
-      {:ok, _} = Journey.get_value(execution, :reminder, wait_any: true)
+      {:ok, _, _} = Journey.get(execution, :reminder, wait: :any)
 
       ocs = Journey.Tools.outstanding_computations(execution.id)
       assert ocs == []

--- a/test/journey/unset_value_test.exs
+++ b/test/journey/unset_value_test.exs
@@ -14,8 +14,8 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :first_name) == {:ok, "Mario"}
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
       execution_after_set = Journey.load(execution)
       original_revision = execution_after_set.revision
@@ -24,7 +24,7 @@ defmodule Journey.JourneyUnsetValueTest do
       execution_after_unset = Journey.unset(execution, :first_name)
 
       # Value should be not_set after unset
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
 
       # Revision should be incremented
       assert execution_after_unset.revision > original_revision
@@ -36,7 +36,7 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
 
       # Value starts as not_set
-      assert Journey.get_value(execution, :first_name) == {:error, :not_set}
+      assert Journey.get(execution, :first_name) == {:error, :not_set}
 
       original_revision = execution.revision
 
@@ -44,7 +44,7 @@ defmodule Journey.JourneyUnsetValueTest do
       execution_after_unset = Journey.unset(execution, :first_name)
 
       # Value should still be not_set
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
 
       # Revision should NOT change since value was already unset
       assert execution_after_unset.revision == original_revision
@@ -56,16 +56,16 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :first_name) == {:ok, "Mario"}
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
 
       # First unset
       execution_after_first_unset = Journey.unset(execution, :first_name)
-      assert Journey.get_value(execution_after_first_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_first_unset, :first_name) == {:error, :not_set}
       first_unset_revision = execution_after_first_unset.revision
 
       # Second unset (should be idempotent)
       execution_after_second_unset = Journey.unset(execution_after_first_unset, :first_name)
-      assert Journey.get_value(execution_after_second_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_second_unset, :first_name) == {:error, :not_set}
 
       # Revision should not change on second unset
       assert execution_after_second_unset.revision == first_unset_revision
@@ -77,18 +77,18 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      assert Journey.get_value(execution, :first_name) == {:ok, "Mario"}
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
       # Unset the value
       execution_after_unset = Journey.unset(execution, :first_name)
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :greeting) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :greeting) == {:error, :not_set}
 
       # Set a new value
       execution_after_reset = Journey.set(execution_after_unset, :first_name, "Luigi")
-      assert Journey.get_value(execution_after_reset, :first_name) == {:ok, "Luigi"}
-      {:ok, "Hello, Luigi"} = Journey.get_value(execution_after_reset, :greeting, wait_any: true)
+      {:ok, "Luigi", _} = Journey.get(execution_after_reset, :first_name)
+      {:ok, "Hello, Luigi", _} = Journey.get(execution_after_reset, :greeting, wait: :any)
     end
 
     test "unsetting value increments revision" do
@@ -97,8 +97,8 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      {:ok, "Mario"} = Journey.get_value(execution, :first_name)
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Mario", _} = Journey.get(execution, :first_name)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
       original_revision = execution.revision
 
@@ -107,14 +107,14 @@ defmodule Journey.JourneyUnsetValueTest do
 
       # Revision should be incremented
       assert execution_after_unset.revision > original_revision
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :greeting) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :greeting) == {:error, :not_set}
 
       # Set a new value and verify recomputation
       execution_after_reset = Journey.set(execution_after_unset, :first_name, "Bob")
       assert execution_after_reset.revision > execution_after_unset.revision
-      assert Journey.get_value(execution_after_reset, :first_name) == {:ok, "Bob"}
-      {:ok, "Hello, Bob"} = Journey.get_value(execution_after_reset, :greeting, wait_any: true)
+      {:ok, "Bob", _} = Journey.get(execution_after_reset, :first_name)
+      {:ok, "Hello, Bob", _} = Journey.get(execution_after_reset, :greeting, wait: :any)
     end
 
     test "unknown node" do
@@ -147,17 +147,17 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
       execution_after_unset = Journey.unset(execution.id, :first_name)
       # Revision will be higher due to cascading invalidation
       assert execution_after_unset.revision > 4
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :greeting) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :greeting) == {:error, :not_set}
 
       # Set a new value and verify recomputation
       execution_after_reset = Journey.set(execution_after_unset, :first_name, "Peach")
-      assert Journey.get_value(execution_after_reset, :first_name) == {:ok, "Peach"}
-      {:ok, "Hello, Peach"} = Journey.get_value(execution_after_reset, :greeting, wait_any: true)
+      {:ok, "Peach", _} = Journey.get(execution_after_reset, :first_name)
+      {:ok, "Hello, Peach", _} = Journey.get(execution_after_reset, :greeting, wait: :any)
     end
 
     test "unset keeps last_updated_at set (not unset)" do
@@ -166,7 +166,7 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
       values_before = Journey.values_all(execution)
       assert {:set, _timestamp} = values_before.last_updated_at
@@ -180,8 +180,8 @@ defmodule Journey.JourneyUnsetValueTest do
 
       # Set a new value and verify recomputation
       execution_after_reset = Journey.set(execution_after_unset, :first_name, "Toad")
-      assert Journey.get_value(execution_after_reset, :first_name) == {:ok, "Toad"}
-      {:ok, "Hello, Toad"} = Journey.get_value(execution_after_reset, :greeting, wait_any: true)
+      {:ok, "Toad", _} = Journey.get(execution_after_reset, :first_name)
+      {:ok, "Hello, Toad", _} = Journey.get(execution_after_reset, :greeting, wait: :any)
 
       # Verify last_updated_at is still set and was updated
       values_after_reset = Journey.values_all(execution_after_reset)
@@ -194,7 +194,7 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
       values_before = Journey.values_all(execution)
       {:set, initial_timestamp} = values_before.last_updated_at
@@ -212,8 +212,8 @@ defmodule Journey.JourneyUnsetValueTest do
 
       # Set a new value and verify recomputation
       execution_after_reset = Journey.set(execution_after_unset, :first_name, "Yoshi")
-      assert Journey.get_value(execution_after_reset, :first_name) == {:ok, "Yoshi"}
-      {:ok, "Hello, Yoshi"} = Journey.get_value(execution_after_reset, :greeting, wait_any: true)
+      {:ok, "Yoshi", _} = Journey.get(execution_after_reset, :first_name)
+      {:ok, "Hello, Yoshi", _} = Journey.get(execution_after_reset, :greeting, wait: :any)
 
       # Verify last_updated_at was updated again
       values_after_reset = Journey.values_all(execution_after_reset)
@@ -242,20 +242,20 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.set(:a, "value")
 
       # Wait for all computations
-      {:ok, "B:value"} = Journey.get_value(execution, :b, wait_any: true)
-      {:ok, "C:B:value"} = Journey.get_value(execution, :c, wait_any: true)
+      {:ok, "B:value", _} = Journey.get(execution, :b, wait: :any)
+      {:ok, "C:B:value", _} = Journey.get(execution, :c, wait: :any)
 
       # Unset :a should cascade to :b and :c
       execution_after_unset = Journey.unset(execution, :a)
 
-      assert Journey.get_value(execution_after_unset, :a) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :b) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :c) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :a) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :b) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :c) == {:error, :not_set}
 
       # Setting :a again should trigger recomputation
       execution_reset = Journey.set(execution_after_unset, :a, "new")
-      {:ok, "B:new"} = Journey.get_value(execution_reset, :b, wait_any: true)
-      {:ok, "C:B:new"} = Journey.get_value(execution_reset, :c, wait_any: true)
+      {:ok, "B:new", _} = Journey.get(execution_reset, :b, wait: :any)
+      {:ok, "C:B:new", _} = Journey.get(execution_reset, :c, wait: :any)
     end
 
     test "handles diamond dependencies" do
@@ -278,24 +278,24 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.set(:a, "val")
 
       # Wait for all computations
-      {:ok, "B:val"} = Journey.get_value(execution, :b, wait_any: true)
-      {:ok, "C:val"} = Journey.get_value(execution, :c, wait_any: true)
-      {:ok, "D:B:val+C:val"} = Journey.get_value(execution, :d, wait_any: true)
+      {:ok, "B:val", _} = Journey.get(execution, :b, wait: :any)
+      {:ok, "C:val", _} = Journey.get(execution, :c, wait: :any)
+      {:ok, "D:B:val+C:val", _} = Journey.get(execution, :d, wait: :any)
 
       # Unset :a should cascade to :b, :c, and :d
       execution_after_unset = Journey.unset(execution, :a)
 
-      assert Journey.get_value(execution_after_unset, :a) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :b) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :c) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :d) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :a) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :b) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :c) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :d) == {:error, :not_set}
 
       # Set :a again and verify all computations trigger
       execution_reset = Journey.set(execution_after_unset, :a, "reset")
-      assert Journey.get_value(execution_reset, :a) == {:ok, "reset"}
-      {:ok, "B:reset"} = Journey.get_value(execution_reset, :b, wait_any: true)
-      {:ok, "C:reset"} = Journey.get_value(execution_reset, :c, wait_any: true)
-      {:ok, "D:B:reset+C:reset"} = Journey.get_value(execution_reset, :d, wait_any: true)
+      {:ok, "reset", _} = Journey.get(execution_reset, :a)
+      {:ok, "B:reset", _} = Journey.get(execution_reset, :b, wait: :any)
+      {:ok, "C:reset", _} = Journey.get(execution_reset, :c, wait: :any)
+      {:ok, "D:B:reset+C:reset", _} = Journey.get(execution_reset, :d, wait: :any)
     end
 
     test "partial dependencies - only affected nodes cascade" do
@@ -320,27 +320,27 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.set(:y, "yval")
 
       # Wait for computations
-      {:ok, "X:xval"} = Journey.get_value(execution, :from_x, wait_any: true)
-      {:ok, "Y:yval"} = Journey.get_value(execution, :from_y, wait_any: true)
-      {:ok, "Both:xval+yval"} = Journey.get_value(execution, :from_both, wait_any: true)
+      {:ok, "X:xval", _} = Journey.get(execution, :from_x, wait: :any)
+      {:ok, "Y:yval", _} = Journey.get(execution, :from_y, wait: :any)
+      {:ok, "Both:xval+yval", _} = Journey.get(execution, :from_both, wait: :any)
 
       # Unset :x should cascade to :from_x and :from_both, but NOT :from_y
       execution_after_unset = Journey.unset(execution, :x)
 
-      assert Journey.get_value(execution_after_unset, :x) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :from_x) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :from_both) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :x) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :from_x) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :from_both) == {:error, :not_set}
       # :from_y should remain set
-      assert Journey.get_value(execution_after_unset, :from_y) == {:ok, "Y:yval"}
-      assert Journey.get_value(execution_after_unset, :y) == {:ok, "yval"}
+      {:ok, "Y:yval", _} = Journey.get(execution_after_unset, :from_y)
+      {:ok, "yval", _} = Journey.get(execution_after_unset, :y)
 
       # Set :x again and verify selective recomputation
       execution_reset = Journey.set(execution_after_unset, :x, "newx")
-      assert Journey.get_value(execution_reset, :x) == {:ok, "newx"}
-      {:ok, "X:newx"} = Journey.get_value(execution_reset, :from_x, wait_any: true)
-      {:ok, "Both:newx+yval"} = Journey.get_value(execution_reset, :from_both, wait_any: true)
+      {:ok, "newx", _} = Journey.get(execution_reset, :x)
+      {:ok, "X:newx", _} = Journey.get(execution_reset, :from_x, wait: :any)
+      {:ok, "Both:newx+yval", _} = Journey.get(execution_reset, :from_both, wait: :any)
       # :from_y should still be the same
-      assert Journey.get_value(execution_reset, :from_y) == {:ok, "Y:yval"}
+      {:ok, "Y:yval", _} = Journey.get(execution_reset, :from_y)
     end
   end
 
@@ -385,7 +385,7 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.set(:email, "mario@example.com")
 
       # Wait for computation
-      {:ok, "Mario Bros"} = Journey.get_value(execution, :full_name, wait_any: true)
+      {:ok, "Mario Bros", _} = Journey.get(execution, :full_name, wait: :any)
 
       original_revision = execution.revision
 
@@ -393,10 +393,10 @@ defmodule Journey.JourneyUnsetValueTest do
       execution_after_unset = Journey.unset(execution, [:first_name, :last_name])
 
       # Check values are unset
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :last_name) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :email) == {:ok, "mario@example.com"}
-      assert Journey.get_value(execution_after_unset, :full_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :last_name) == {:error, :not_set}
+      {:ok, "mario@example.com", _} = Journey.get(execution_after_unset, :email)
+      assert Journey.get(execution_after_unset, :full_name) == {:error, :not_set}
 
       # Revision should be incremented (may be more than +1 due to cascading invalidation)
       assert execution_after_unset.revision > original_revision
@@ -408,13 +408,13 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.start_execution()
         |> Journey.set(:first_name, "Mario")
 
-      {:ok, "Hello, Mario"} = Journey.get_value(execution, :greeting, wait_any: true)
+      {:ok, "Hello, Mario", _} = Journey.get(execution, :greeting, wait: :any)
 
       # Unset using execution ID
       execution_after_unset = Journey.unset(execution.id, [:first_name])
 
-      assert Journey.get_value(execution_after_unset, :first_name) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :greeting) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :first_name) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :greeting) == {:error, :not_set}
     end
 
     test "unset multiple values - idempotent behavior" do
@@ -490,24 +490,24 @@ defmodule Journey.JourneyUnsetValueTest do
         |> Journey.set(:c, "C")
 
       # Wait for all computations
-      {:ok, "A+B"} = Journey.get_value(execution, :ab, wait_any: true)
-      {:ok, "B+C"} = Journey.get_value(execution, :bc, wait_any: true)
-      {:ok, "A+B+B+C"} = Journey.get_value(execution, :abc, wait_any: true)
+      {:ok, "A+B", _} = Journey.get(execution, :ab, wait: :any)
+      {:ok, "B+C", _} = Journey.get(execution, :bc, wait: :any)
+      {:ok, "A+B+B+C", _} = Journey.get(execution, :abc, wait: :any)
 
       # Unset :a and :b should cascade appropriately
       execution_after_unset = Journey.unset(execution, [:a, :b])
 
       # Check what's unset
-      assert Journey.get_value(execution_after_unset, :a) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :b) == {:error, :not_set}
-      assert Journey.get_value(execution_after_unset, :c) == {:ok, "C"}
+      assert Journey.get(execution_after_unset, :a) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :b) == {:error, :not_set}
+      {:ok, "C", _} = Journey.get(execution_after_unset, :c)
 
       # :ab should be unset (depends on both :a and :b)
-      assert Journey.get_value(execution_after_unset, :ab) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :ab) == {:error, :not_set}
       # :bc should be unset (depends on :b)
-      assert Journey.get_value(execution_after_unset, :bc) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :bc) == {:error, :not_set}
       # :abc should be unset (depends on :ab and :bc)
-      assert Journey.get_value(execution_after_unset, :abc) == {:error, :not_set}
+      assert Journey.get(execution_after_unset, :abc) == {:error, :not_set}
     end
   end
 end

--- a/test_load/sunny_day.ex
+++ b/test_load/sunny_day.ex
@@ -20,9 +20,9 @@ defmodule LoadTest.SunnyDay do
             e = lifetime_success_flow(e)
 
             e
-            |> Journey.get_value(:archive)
+            |> Journey.get(:archive)
             |> case do
-              {:ok, _} ->
+              {:ok, _, _} ->
                 Logger.debug("#{e.id}: execution completed successfully.")
 
               _huh ->
@@ -72,15 +72,15 @@ defmodule LoadTest.SunnyDay do
 
     Process.sleep(4_000)
 
-    {:ok, _credit_score} = e |> Journey.get_value(:credit_score, wait_any: 45_000)
-    {:ok, _decision} = e |> Journey.get_value(:preapproval_decision, wait_any: 45_000)
-    {:ok, true} = e |> Journey.get_value(:preapproval_process_completed, wait_any: 45_000)
-    {:ok, true} = e |> Journey.get_value(:send_preapproval_reminder, wait_any: 45_000)
+    {:ok, _credit_score, _} = e |> Journey.get(:credit_score, wait: :any, timeout: 45_000)
+    {:ok, _decision, _} = e |> Journey.get(:preapproval_decision, wait: :any, timeout: 45_000)
+    {:ok, true, _} = e |> Journey.get(:preapproval_process_completed, wait: :any, timeout: 45_000)
+    {:ok, true, _} = e |> Journey.get(:send_preapproval_reminder, wait: :any, timeout: 45_000)
     e = e |> Journey.set(:credit_card_requested, true)
-    {:ok, true} = e |> Journey.get_value(:initiate_credit_card_issuance, wait_any: 45_000)
+    {:ok, true, _} = e |> Journey.get(:initiate_credit_card_issuance, wait: :any, timeout: 45_000)
     e = e |> Journey.set(:credit_card_mailed, true)
-    {:ok, true} = e |> Journey.get_value(:credit_card_mailed_notification, wait_any: 45_000)
-    {:ok, _} = e |> Journey.get_value(:archive, wait_any: 45_000)
+    {:ok, true, _} = e |> Journey.get(:credit_card_mailed_notification, wait: :any, timeout: 45_000)
+    {:ok, _, _} = e |> Journey.get(:archive, wait: :any, timeout: 45_000)
     Logger.info("lifetime_success_flow[#{e.id}]: completed")
 
     e


### PR DESCRIPTION
…deprecating get_value