### PR TITLE
adding `Journey.Tools.abandon_computation/1`

### DIFF
--- a/MODULES_AND_FUNCTIONS.md
+++ b/MODULES_AND_FUNCTIONS.md
@@ -58,6 +58,7 @@ Functions:
 Utility functions for debugging, analysis, and visualization of Journey executions.
 
 Functions:
+- `Journey.Tools.abandon_computation/1` - Manually abandons a computation in :computing state, scheduling a retry if max_retries not exhausted
 - `Journey.Tools.computation_state/2` - Returns the current state of a computation node (:not_set, :computing, :success, :failed, etc.)
 - `Journey.Tools.computation_state_to_text/1` - Converts a computation state atom to human-readable text with visual symbols
 - `Journey.Tools.computation_status_as_text/2` - Shows the status and dependencies for a single computation node


### PR DESCRIPTION

 Adds a manual tool to abandon stuck computations in the `:computing` state.
  This mimics the automatic abandonment sweeper behavior by:
  - Verifying the computation is in the `:computing` state.
  - Scheduling a retry if `max_retries` allows.
  - Marking the computation as `:abandoned`.
  - Kicking the execution to trigger downstream processing.
   
This is useful for operational interventions when a computation is known to be stuck or problematic before the automatic timeout is reached.
