### PR TITLE
`Journey.Tools.introspect(eid)` output to include computations' times

### DIFF
--- a/lib/journey/tools.ex
+++ b/lib/journey/tools.ex
@@ -826,10 +826,15 @@ defmodule Journey.Tools do
          state: state,
          computation_type: computation_type,
          computed_with: computed_with,
-         ex_revision_at_completion: ex_revision_at_completion
+         ex_revision_at_completion: ex_revision_at_completion,
+         start_time: start_time,
+         completion_time: completion_time
        }) do
+    timing_line = format_computation_timing(start_time, completion_time)
+
     "  - :#{node_name} (#{id}): #{computation_state_to_text(state)} | #{inspect(computation_type)} | rev #{ex_revision_at_completion}\n" <>
-      "    inputs used: \n" <>
+      timing_line <>
+      "    inputs used:\n" <>
       case computed_with do
         nil ->
           "       <none>\n"
@@ -848,7 +853,7 @@ defmodule Journey.Tools do
   defp outstanding_computation(
          graph,
          values,
-         %{node_name: node_name, state: state, computation_type: computation_type},
+         %{node_name: node_name, state: state, computation_type: computation_type, start_time: start_time},
          with_header?
        ) do
     case Graph.find_node_by_name(graph, node_name) do
@@ -875,10 +880,45 @@ defmodule Journey.Tools do
             ""
           end
 
+        timing_line = format_outstanding_timing(state, start_time)
+
         formatted_conditions = format_condition_tree(readiness.structure, "       ")
 
-        header <> formatted_conditions
+        header <> timing_line <> formatted_conditions
     end
+  end
+
+  defp format_computation_timing(start_time, completion_time)
+       when is_integer(start_time) and is_integer(completion_time) do
+    duration = completion_time - start_time
+
+    "    started: #{DateTime.from_unix!(start_time)} | completed: #{DateTime.from_unix!(completion_time)} (#{format_duration_seconds(duration)})\n"
+  end
+
+  defp format_computation_timing(_start_time, _completion_time), do: ""
+
+  defp format_outstanding_timing(:computing, start_time) when is_integer(start_time) do
+    now = System.system_time(:second)
+    elapsed = now - start_time
+    "    started: #{DateTime.from_unix!(start_time)} | running for #{format_duration_seconds(elapsed)}\n"
+  end
+
+  defp format_outstanding_timing(_state, _start_time), do: ""
+
+  defp format_duration_seconds(seconds) when seconds < 60, do: "#{seconds}s"
+
+  defp format_duration_seconds(seconds) when seconds < 3600 do
+    minutes = div(seconds, 60)
+    remaining = rem(seconds, 60)
+    "#{minutes}m #{remaining}s"
+  end
+
+  defp format_duration_seconds(seconds) do
+    hours = div(seconds, 3600)
+    remaining = rem(seconds, 3600)
+    minutes = div(remaining, 60)
+    secs = rem(remaining, 60)
+    "#{hours}h #{minutes}m #{secs}s"
   end
 
   # Helper function to format node values appropriately

--- a/test/journey/tools_test.exs
+++ b/test/journey/tools_test.exs
@@ -162,6 +162,7 @@ defmodule Journey.ToolsTest do
         |> redact_text_timestamps()
         |> redact_text_duration()
         |> redact_text_seconds_ago()
+        |> redact_text_computation_timing()
         |> String.replace(~r/CMP[A-Z0-9]+/, "CMPREDACTED")
 
       expected_output = """
@@ -203,13 +204,16 @@ defmodule Journey.ToolsTest do
       Computations:
       - Completed:
         - :reminder (CMPREDACTED): ✅ :success | :compute | rev 7
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :time_to_issue_reminder_schedule (rev 5)
         - :time_to_issue_reminder_schedule (CMPREDACTED): ✅ :success | :tick_once | rev 5
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :greeting (rev 3)
         - :greeting (CMPREDACTED): ✅ :success | :compute | rev 3
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :user_name (rev 1)
 
       - Outstanding:
@@ -348,6 +352,7 @@ defmodule Journey.ToolsTest do
         |> redact_text_timestamps()
         |> redact_text_duration()
         |> redact_text_seconds_ago()
+        |> redact_text_computation_timing()
         |> String.replace(~r/CMP[A-Z0-9]+/, "CMPREDACTED")
 
       # Complete expected output as living documentation for engineers
@@ -392,11 +397,13 @@ defmodule Journey.ToolsTest do
       Computations:
       - Completed:
         - :send_follow_up (CMPREDACTED): ✅ :success | :compute | rev 4
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :user_applied (rev 0)
              :card_mailed (rev 0)
         - :send_reminder (CMPREDACTED): ✅ :success | :compute | rev 3
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :user_requested_card (rev 0)
 
       - Outstanding:
@@ -460,10 +467,12 @@ defmodule Journey.ToolsTest do
       Computations:
       - Completed:
         - :send_reminder (CMPREDACTED): ✅ :success | :compute | rev 4
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :user_requested_card (rev 0)
         - :send_follow_up (CMPREDACTED): ✅ :success | :compute | rev 3
-          inputs used: 
+          started: REDACTED | completed: REDACTED (REDACTED)
+          inputs used:
              :user_applied (rev 0)
              :card_mailed (rev 0)
 
@@ -486,6 +495,26 @@ defmodule Journey.ToolsTest do
                String.trim(expected_output),
                String.trim(expected_output_alt)
              ]
+    end
+
+    test "completed computations include start and completion timestamps" do
+      graph =
+        Journey.new_graph("timestamps test #{random_string()}", "v1.0.0", [
+          input(:value),
+          compute(:doubled, [:value], fn %{value: v} -> {:ok, v * 2} end)
+        ])
+
+      execution =
+        Journey.start_execution(graph)
+        |> Journey.set(:value, 5)
+
+      {:ok, _, _} = Journey.get(execution, :doubled, wait: :any)
+
+      result = Journey.Tools.introspect(execution.id)
+
+      # Assert that the completed computation includes timestamp information
+      assert result =~
+               ~r/started: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}Z \| completed: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}Z \(\d+s\)/
     end
   end
 
@@ -887,6 +916,16 @@ defmodule Journey.ToolsTest do
   defp redact_text_seconds_ago(text) do
     text
     |> String.replace(~r/\d+ seconds ago/, "REDACTED seconds ago")
+  end
+
+  defp redact_text_computation_timing(text) do
+    text
+    |> String.replace(~r/\(\d+s\)/, "(REDACTED)")
+    |> String.replace(~r/\(\d+m \d+s\)/, "(REDACTED)")
+    |> String.replace(~r/\(\d+h \d+m \d+s\)/, "(REDACTED)")
+    |> String.replace(~r/running for \d+s/, "running for REDACTED")
+    |> String.replace(~r/running for \d+m \d+s/, "running for REDACTED")
+    |> String.replace(~r/running for \d+h \d+m \d+s/, "running for REDACTED")
   end
 
   # Helper to reliably wait for a computation to reach a specific state.


### PR DESCRIPTION
Journey.Tools.introspect() to include timing information for completed executions.e.g.:

```
iex(3)>  ourney.Tools.introspect("EXECY149V0X361AEB0T1EYL6") |> IO.puts()
Execution summary:
- ID: 'EXECY149V0X361AEB0T1EYL6'
- Graph: 'Useless Machine graph 0 Elixir.Journey.Scheduler.Scheduler.MutateTest' | 'v1.0.0'
- Archived at: not archived
- Created at: 2026-03-18 17:41:23Z UTC | 2 seconds ago
- Last updated at: 2026-03-18 17:41:25Z UTC | 0 seconds ago
- Duration: 2 seconds
- Revision: 12
- # of Values: 4 (set) / 4 (total)
- # of Computations: 4

Values:
- Set:
  - last_updated_at: '1773855685' | :input
    set at 2026-03-18 17:41:25Z | rev: 12

  - turn_off: '"updated :switch_position"' | :mutate
    computed at 2026-03-18 17:41:25Z | rev: 12

  - switch_position: '"off"' | :input
    set at 2026-03-18 17:41:25Z | rev: 10

  - execution_id: 'EXECY149V0X361AEB0T1EYL6' | :input
    set at 2026-03-18 17:41:23Z | rev: 0


- Not set:


Computations:
- Completed:
  - :turn_off (CMP192ZYG24Z9TDD1JD9RGL): ✅ :success | :mutate | rev 12
    started: 2026-03-18 17:41:25Z | completed: 2026-03-18 17:41:25Z (0s)
    inputs used:
       :switch_position (rev 10)
  - :turn_off (CMPVHGL46YLV6B1D12L2GYY): ✅ :success | :mutate | rev 9
    started: 2026-03-18 17:41:24Z | completed: 2026-03-18 17:41:24Z (0s)
    inputs used:
       :switch_position (rev 7)
  - :turn_off (CMPG22HA734M27B2HDDLE3D): ✅ :success | :mutate | rev 6
    started: 2026-03-18 17:41:24Z | completed: 2026-03-18 17:41:24Z (0s)
    inputs used:
       :switch_position (rev 4)
  - :turn_off (CMP9A4EYTZXGT29RJ5A54EY): ✅ :success | :mutate | rev 3
    started: 2026-03-18 17:41:23Z | completed: 2026-03-18 17:41:23Z (0s)
    inputs used:
       :switch_position (rev 1)

- Outstanding:
```