### PR TITLE
updating license to include SPDX' LicenseRef- prefix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Journey.MixProject do
       name: "journey",
       description:
         "Journey is a library for defining and running durable workflows with persistence, reliability, and scalability.",
-      licenses: ["Journey License"],
+      licenses: ["LicenseRef-Journey"],
       links: %{
         "GitHub" => "https://github.com/shipworthy/journey",
         "License" => "https://github.com/shipworthy/journey/blob/v#{@version}/LICENSE.md",


### PR DESCRIPTION
After https://github.com/hexpm/hexpm/pull/1551 and https://github.com/hexpm/hexpm/pull/1562 , to publish a package with a custom license, the license needs to use the `LicenseRef-` prefix (per [SPDX](https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/)).

Updating Journey license string to include the `LicenseRef-` prefix.